### PR TITLE
Add installer role for running the foreman-installer

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -110,3 +110,32 @@ jobs:
         with:
           name: collection
           path: theforeman-operations-*.tar.gz
+
+  molecule:
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 4
+      matrix:
+        ansible:
+          - stable-2.9
+          - stable-2.10
+          - devel
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.7"
+      - name: Install Ansible
+        run: pip install --upgrade git+https://github.com/ansible/ansible.git@${{ matrix.ansible }}
+      - name: Install dependencies
+        run: make test-setup
+      - name: Run tests
+        env:
+          DRIVER_NAME: docker
+        run: |
+          for roledir in roles/*/molecule; do
+            pushd $(dirname $roledir)
+            molecule test
+            popd
+          done

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,4 @@
+---
+rules:
+  line-length:
+    max: 140

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ ROLES := $(wildcard roles/*)
 PLUGIN_TYPES := $(filter-out __%,$(notdir $(wildcard plugins/*)))
 METADATA := galaxy.yml LICENSE README.md requirements.txt CHANGELOG.rst
 $(foreach PLUGIN_TYPE,$(PLUGIN_TYPES),$(eval _$(PLUGIN_TYPE) := $(filter-out %__init__.py,$(wildcard plugins/$(PLUGIN_TYPE)/*.py))))
-DEPENDENCIES := $(METADATA) $(foreach PLUGIN_TYPE,$(PLUGIN_TYPES),$(_$(PLUGIN_TYPE))) $(foreach ROLE,$(ROLES),$(wildcard $(ROLE)/*/*))
+DEPENDENCIES := $(METADATA) $(foreach PLUGIN_TYPE,$(PLUGIN_TYPES),$(_$(PLUGIN_TYPE))) $(foreach ROLE,$(ROLES),$(filter-out $(ROLE)/molecule/%, $(wildcard $(ROLE)/*/*)))
 
 PYTHON_VERSION = $(shell python -c 'import sys; print("{}.{}".format(sys.version_info.major, sys.version_info.minor))')
 COLLECTION_COMMAND ?= ansible-galaxy

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,9 +1,3 @@
-pytest
-pytest-xdist
-vcrpy
-ansible_runner
-python-debian
-rpm-py-installer
 docker
 cryptography<3.1; python_version < '3.6'
 -r requirements-lint.txt
@@ -12,3 +6,4 @@ cryptography<3.1; python_version < '3.6'
 -r https://github.com/ansible/ansible/raw/devel/test/lib/ansible_test/_data/requirements/sanity.rstcheck.txt
 -r https://github.com/ansible/ansible/raw/devel/test/lib/ansible_test/_data/requirements/sanity.yamllint.txt
 -r https://github.com/ansible/ansible/raw/devel/test/lib/ansible_test/_data/requirements/sanity.validate-modules.txt
+molecule[docker]

--- a/roles/installer/README.md
+++ b/roles/installer/README.md
@@ -1,0 +1,32 @@
+theforeman.operations.installer
+===============================
+
+Run the foreman-installer
+
+Role Variables
+--------------
+
+Required:
+
+- `installer_scenario`: The installer scenario to run, this is required to be set
+
+Optional:
+
+- `installer_options`: Array of options to pass to the installer
+- `installer_verbose`: Enables verbose output mode in the installer
+- `installer_no_colors`: Disables color output from the installer
+- `installer_command`: Installer command to run, can be used by derivative projects to specify a branded command
+
+Example Playbooks
+-----------------
+
+Run the installer setting the initial admin password:
+
+```yaml
+- hosts: target-host
+  roles:
+    - role: theforeman.operations.installer
+      vars:
+        installer_options:
+          - '--foreman-initial-admin-password changeme'
+```

--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+installer_command: foreman-installer
+installer_verbose: true
+installer_no_colors: false
+installer_options: []

--- a/roles/installer/molecule/default/converge.yml
+++ b/roles/installer/molecule/default/converge.yml
@@ -1,0 +1,10 @@
+---
+- name: Converge
+  hosts: all
+  gather_facts: false
+  vars:
+    installer_scenario: foreman
+    installer_options:
+      - '--foreman-initial-admin-password changeme'
+  roles:
+    - installer

--- a/roles/installer/molecule/default/molecule.yml
+++ b/roles/installer/molecule/default/molecule.yml
@@ -1,0 +1,22 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ${DRIVER_NAME:-podman}
+platforms:
+  - name: foreman.example.com
+    image: centos:8
+    command: /sbin/init
+    tmpfs:
+      - /run
+      - /tmp:exec,mode=777
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+provisioner:
+  name: ansible
+verifier:
+  name: ansible
+lint: |
+  set -e
+  yamllint -c ../../.yamllint .
+  ansible-lint .

--- a/roles/installer/molecule/default/prepare.yml
+++ b/roles/installer/molecule/default/prepare.yml
@@ -1,0 +1,22 @@
+---
+- name: Prepare
+  hosts: all
+  gather_facts: true
+  become: true
+  tasks:
+    - name: 'Setup Foreman latest repository'
+      yum:
+        name: https://yum.theforeman.org/releases/latest/el{{ ansible_distribution_major_version }}/x86_64/foreman-release.rpm
+        disable_gpg_check: true
+        state: present
+
+    - name: 'Setup Puppet 6 Repository'
+      yum:
+        name: https://yum.puppet.com/puppet6-release-el-{{ ansible_distribution_major_version }}.noarch.rpm
+        disable_gpg_check: true
+        state: present
+
+    - name: Install foreman-installer
+      package:
+        name: foreman-installer
+        state: present

--- a/roles/installer/molecule/default/verify.yml
+++ b/roles/installer/molecule/default/verify.yml
@@ -1,0 +1,10 @@
+---
+- name: Converge
+  hosts: all
+  gather_facts: false
+  vars:
+    installer_scenario: foreman
+    installer_verbose: true
+    installer_no_colors: false
+  roles:
+    - installer

--- a/roles/installer/tasks/main.yml
+++ b/roles/installer/tasks/main.yml
@@ -1,0 +1,29 @@
+---
+- name: Check that necessary variables are defined
+  assert:
+    that:
+      - installer_scenario is defined
+
+- name: Check if initial install has happened
+  stat:
+    path: /etc/foreman-installer/scenarios.d/.installed
+  register: installed
+
+- name: 'Check if changes are needed by running installer in noop mode'
+  command: >
+    {{ installer_command }}
+    --scenario {{ installer_scenario }}
+    --noop
+  register: installer_noop
+  changed_when: false
+  failed_when: installer_noop.rc not in [0, 2]
+  when: installed.stat.exists
+
+- name: 'Run installer'
+  command: >
+    {{ installer_command }}
+    --scenario {{ installer_scenario }}
+    {{ (installer_verbose|bool) | ternary("-v", "") }}
+    {{ (installer_no_colors|bool) | ternary("--no-colors", "") }}
+    {{ installer_options | join(' ') }}
+  when: installer_noop.rc is not defined or installer_noop.rc == 2


### PR DESCRIPTION
Starting with an initial role for the foreman_installer providing the most basic of functionality regarding the installer. There are many sources of inspiration for this role, and of varying complexity and handling. I wanted to start with the simplest, most re-usable form of that functionality.

I am starting this in Draft format to see what others think and also to try to figure out the appropriate level of testing for a role of this type.