### PR TITLE
properly detect if an installer run is required

### DIFF
--- a/roles/installer/molecule/default/converge.yml
+++ b/roles/installer/molecule/default/converge.yml
@@ -4,7 +4,13 @@
   gather_facts: false
   vars:
     installer_scenario: foreman
-    installer_options:
-      - '--foreman-initial-admin-password changeme'
   roles:
-    - installer
+    - role: installer
+      vars:
+        installer_options:
+          - '--foreman-initial-admin-password changeme'
+    - role: installer
+      vars:
+        installer_options:
+          - '--foreman-initial-admin-password changeme'
+          - '--enable-foreman-plugin-tasks'

--- a/roles/installer/molecule/default/converge.yml
+++ b/roles/installer/molecule/default/converge.yml
@@ -6,11 +6,7 @@
     installer_scenario: foreman
   roles:
     - role: installer
-      vars:
-        installer_options:
-          - '--foreman-initial-admin-password changeme'
     - role: installer
       vars:
         installer_options:
-          - '--foreman-initial-admin-password changeme'
           - '--enable-foreman-plugin-tasks'

--- a/roles/installer/molecule/default/verify.yml
+++ b/roles/installer/molecule/default/verify.yml
@@ -8,3 +8,12 @@
     installer_no_colors: false
   roles:
     - installer
+  tasks:
+    - name: find tasks config file
+      stat:
+        path: /etc/foreman/plugins/foreman-tasks.yaml
+      register: foreman_tasks_yaml
+    - name: check tasks config file exists
+      assert:
+        that:
+          - foreman_tasks_yaml.stat.exists

--- a/roles/installer/tasks/main.yml
+++ b/roles/installer/tasks/main.yml
@@ -4,23 +4,6 @@
     that:
       - installer_scenario is defined
 
-- name: Check if initial install has happened
-  stat:
-    path: /etc/foreman-installer/scenarios.d/.installed
-  register: installed
-
-- name: 'Check if changes are needed by running installer in noop mode'
-  command: >
-    {{ installer_command }}
-    --scenario {{ installer_scenario }}
-    {{ installer_options | join(' ') }}
-    --noop
-    --detailed-exitcodes
-  register: installer_noop
-  changed_when: false
-  failed_when: installer_noop.rc not in [0, 2]
-  when: installed.stat.exists
-
 - name: 'Run installer'
   command: >
     {{ installer_command }}
@@ -28,4 +11,7 @@
     {{ (installer_verbose|bool) | ternary("-v", "") }}
     {{ (installer_no_colors|bool) | ternary("--no-colors", "") }}
     {{ installer_options | join(' ') }}
-  when: installer_noop.rc is not defined or installer_noop.rc == 2
+    --detailed-exitcodes
+  register: installer_run
+  changed_when: installer_run.rc == 2
+  failed_when: installer_run.rc not in [0, 2]

--- a/roles/installer/tasks/main.yml
+++ b/roles/installer/tasks/main.yml
@@ -13,7 +13,9 @@
   command: >
     {{ installer_command }}
     --scenario {{ installer_scenario }}
+    {{ installer_options | join(' ') }}
     --noop
+    --detailed-exitcodes
   register: installer_noop
   changed_when: false
   failed_when: installer_noop.rc not in [0, 2]


### PR DESCRIPTION
1. we need to pass the same installer options, as otherwise changed options
would not trigger an installer run
2. we need to enable detailed exitcodes, as otherwise installer never exits
with code 2 when there are pending changes