### PR TITLE
Add role to setup Foreman repositories

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -136,6 +136,6 @@ jobs:
         run: |
           for roledir in roles/*/molecule; do
             pushd $(dirname $roledir)
-            molecule test
+            molecule test --all
             popd
           done

--- a/.yamllint
+++ b/.yamllint
@@ -1,4 +1,4 @@
 ---
 rules:
   line-length:
-    max: 140
+    max: 200

--- a/roles/foreman_repositories/README.md
+++ b/roles/foreman_repositories/README.md
@@ -1,0 +1,40 @@
+theforeman.operations.foreman_repositories
+==========================================
+
+Sets up the Foreman and plugin repositories.
+
+Role Variables
+--------------
+
+Optional:
+
+- `foreman_repositories_version`: Version of Foreman to setup repositories for (default: 2.3)
+- `foreman_repositories_katello_version`: Version of Katello to setup repositories for, set a value for this to configure Katello repositories otherwise no Katello repositories will be configured (default: null)
+
+Example Playbooks
+-----------------
+
+Setup repositories for Foreman 2.3:
+
+```
+---
+- hosts: all
+  gather_facts: true
+  vars:
+    foreman_repositories_version: "2.3"
+  roles:
+    - foreman_repositories
+```
+
+Setup repositories for Katello 3.18 and Foreman 2.3:
+
+```
+---
+- hosts: all
+  gather_facts: true
+  vars:
+    foreman_repositories_version: "2.3"
+    foreman_repositories_katello_version: "3.18"
+  roles:
+    - foreman_repositories
+```

--- a/roles/foreman_repositories/defaults/main.yml
+++ b/roles/foreman_repositories/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+foreman_repositories_version: "2.3"

--- a/roles/foreman_repositories/molecule/debian/converge.yml
+++ b/roles/foreman_repositories/molecule/debian/converge.yml
@@ -1,0 +1,6 @@
+---
+- name: Converge
+  hosts: all
+  gather_facts: true
+  roles:
+    - foreman_repositories

--- a/roles/foreman_repositories/molecule/debian/molecule.yml
+++ b/roles/foreman_repositories/molecule/debian/molecule.yml
@@ -1,0 +1,16 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ${DRIVER_NAME:-podman}
+platforms:
+  - name: debian-buster
+    image: debian:buster
+provisioner:
+  name: ansible
+verifier:
+  name: ansible
+lint: |
+  set -e
+  yamllint -c ../../.yamllint .
+  ansible-lint .

--- a/roles/foreman_repositories/molecule/debian/verify.yml
+++ b/roles/foreman_repositories/molecule/debian/verify.yml
@@ -1,0 +1,15 @@
+---
+- name: Verify
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name:
+      slurp:
+        path: /etc/apt/sources.list.d/deb_theforeman_org.list
+      register: repos
+
+    - name: check foreman repos exists
+      assert:
+        that:
+          - "'deb http://deb.theforeman.org buster 2.3' in repos['content'] | b64decode"
+          - "'deb http://deb.theforeman.org plugins 2.3' in repos['content'] | b64decode"

--- a/roles/foreman_repositories/molecule/redhat/converge.yml
+++ b/roles/foreman_repositories/molecule/redhat/converge.yml
@@ -1,0 +1,8 @@
+---
+- name: Converge
+  hosts: all
+  gather_facts: true
+  vars:
+    foreman_repositories_katello_version: "3.18"
+  roles:
+    - foreman_repositories

--- a/roles/foreman_repositories/molecule/redhat/molecule.yml
+++ b/roles/foreman_repositories/molecule/redhat/molecule.yml
@@ -1,0 +1,30 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ${DRIVER_NAME:-podman}
+platforms:
+  - name: centos8
+    image: centos:8
+    command: /sbin/init
+    tmpfs:
+      - /run
+      - /tmp:exec,mode=777
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+  - name: centos7
+    image: centos:7
+    command: /sbin/init
+    tmpfs:
+      - /run
+      - /tmp:exec,mode=777
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+provisioner:
+  name: ansible
+verifier:
+  name: ansible
+lint: |
+  set -e
+  yamllint -c ../../.yamllint .
+  ansible-lint .

--- a/roles/foreman_repositories/molecule/redhat/verify.yml
+++ b/roles/foreman_repositories/molecule/redhat/verify.yml
@@ -1,0 +1,44 @@
+---
+- name: Verify
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Ensure foreman-release is installed
+      package:
+        name: foreman-release
+        state: present
+
+    - name: Ensure katello-repos is installed
+      package:
+        name: katello-repos
+        state: present
+
+    - name:
+      stat:
+        path: /etc/yum.repos.d/foreman.repo
+      register: foreman_repo
+
+    - name: check foreman_repo file exists
+      assert:
+        that:
+          - foreman_repo.stat.exists
+
+    - name:
+      stat:
+        path: /etc/yum.repos.d/foreman-plugins.repo
+      register: foreman_plugins_repo
+
+    - name: check foreman_plugins_repo file exists
+      assert:
+        that:
+          - foreman_plugins_repo.stat.exists
+
+    - name:
+      stat:
+        path: /etc/yum.repos.d/katello.repo
+      register: katello_repo
+
+    - name: check katello_repo file exists
+      assert:
+        that:
+          - katello_repo.stat.exists

--- a/roles/foreman_repositories/tasks/debian.yml
+++ b/roles/foreman_repositories/tasks/debian.yml
@@ -1,0 +1,22 @@
+---
+- name: 'Install GPG package'
+  package:
+    name: 'gpg'
+    state: present
+    update_cache: yes
+  tags:
+    - packages
+
+- name: 'Install Foreman GPG key'
+  apt_key:
+    url: https://deb.theforeman.org/foreman.asc
+
+- name: 'Setup Foreman {{ foreman_repositories_version }} repository'
+  apt_repository:
+    repo: deb http://deb.theforeman.org {{ ansible_distribution_release }} {{ foreman_repositories_version }}
+    state: present
+
+- name: 'Setup Foreman {{ foreman_repositories_version }} plugins repository'
+  apt_repository:
+    repo: deb http://deb.theforeman.org plugins {{ foreman_repositories_version }}
+    state: present

--- a/roles/foreman_repositories/tasks/main.yml
+++ b/roles/foreman_repositories/tasks/main.yml
@@ -1,0 +1,2 @@
+---
+- include_tasks: "{{ ansible_os_family|lower }}.yml"

--- a/roles/foreman_repositories/tasks/redhat.yml
+++ b/roles/foreman_repositories/tasks/redhat.yml
@@ -1,0 +1,26 @@
+---
+- name: 'Install centos-release-scl-rh' # noqa 403
+  yum:
+    name: centos-release-scl-rh
+    state: latest
+    update_cache: yes
+  tags:
+    - packages
+  when:
+    - ansible_distribution == 'CentOS'
+    - ansible_distribution_major_version == '7'
+
+- name: 'Setup Foreman {{ foreman_repositories_version }} Repository'
+  yum:
+    name: https://yum.theforeman.org/releases/{{ foreman_repositories_version }}/el{{ ansible_distribution_major_version }}/x86_64/foreman-release.rpm
+    disable_gpg_check: True
+    state: present
+  tags:
+    - packages
+
+- name: 'Setup Katello {{ foreman_repositories_katello_version }} Repository'
+  yum:
+    name: https://fedorapeople.org/groups/katello/releases/yum/{{ foreman_repositories_katello_version }}/katello/el{{ ansible_distribution_major_version }}/x86_64/katello-repos-latest.rpm # noqa 204
+    disable_gpg_check: True
+    state: present
+  when: foreman_repositories_katello_version is defined


### PR DESCRIPTION
Starter to fix #9 and to open up a few questions as I build it out:

 1) Should we actually include staging repository setup in this collection? (its a bit of CI / dev resource)
 2) Should this role be simply named `repositories` ?
 3) Should this role handle Katello and Pulpcore repositories rather than as separate roles like we have in Forklift?

I am attempting to not just blindly copy Forklift but think about the context of this collection.