### PR TITLE
Fixes #20: Support upgrading puppet major versions

### DIFF
--- a/roles/puppet_repositories/molecule/debian/prepare.yml
+++ b/roles/puppet_repositories/molecule/debian/prepare.yml
@@ -1,8 +1,8 @@
 ---
-- name: Converge
+- name: Prepare
   hosts: all
   gather_facts: true
   vars:
-    puppet_repositories_version: 6
+    puppet_repositories_version: 5
   roles:
     - puppet_repositories

--- a/roles/puppet_repositories/molecule/debian/verify.yml
+++ b/roles/puppet_repositories/molecule/debian/verify.yml
@@ -3,12 +3,12 @@
   hosts: all
   gather_facts: false
   tasks:
-    - name:
-      slurp:
-        path: /etc/apt/sources.list.d/puppet6.list
-      register: repos
+    - name: Ensure puppet5-release package is absent
+      package:
+        name: puppet5-release
+        state: absent
 
-    - name: check puppet repo exists
-      assert:
-        that:
-          - "'deb http://apt.puppetlabs.com buster puppet6' in repos['content'] | b64decode"
+    - name: Ensure puppet6-release package is present
+      package:
+        name: puppet6-release
+        state: present

--- a/roles/puppet_repositories/molecule/redhat/converge.yml
+++ b/roles/puppet_repositories/molecule/redhat/converge.yml
@@ -2,5 +2,7 @@
 - name: Converge
   hosts: all
   gather_facts: true
+  vars:
+    puppet_repositories_version: 6
   roles:
     - puppet_repositories

--- a/roles/puppet_repositories/molecule/redhat/prepare.yml
+++ b/roles/puppet_repositories/molecule/redhat/prepare.yml
@@ -1,8 +1,8 @@
 ---
-- name: Converge
+- name: Prepare
   hosts: all
   gather_facts: true
   vars:
-    puppet_repositories_version: 6
+    puppet_repositories_version: 5
   roles:
     - puppet_repositories

--- a/roles/puppet_repositories/molecule/redhat/verify.yml
+++ b/roles/puppet_repositories/molecule/redhat/verify.yml
@@ -3,7 +3,12 @@
   hosts: all
   gather_facts: false
   tasks:
-    - name: Ensure puppet release RPM is installed
+    - name: Ensure puppet5-release RPM is absent
+      package:
+        name: puppet5-release
+        state: absent
+
+    - name: Ensure puppet6-release RPM is installed
       package:
         name: puppet6-release
         state: present

--- a/roles/puppet_repositories/tasks/main.yml
+++ b/roles/puppet_repositories/tasks/main.yml
@@ -1,3 +1,9 @@
 ---
+- name: Remove any existing Puppet release packages for versions other than {{ puppet_repositories_version }}
+  package:
+    name: "puppet{{ item }}-release"
+    state: absent
+  loop: "{{ puppet_repositories_supported_versions | difference([puppet_repositories_version | string]) }}"
+
 - name: 'Include {{ ansible_os_family }}'
   include_tasks: '{{ ansible_os_family|lower }}.yml'

--- a/roles/puppet_repositories/vars/main.yml
+++ b/roles/puppet_repositories/vars/main.yml
@@ -1,0 +1,3 @@
+puppet_repositories_supported_versions:
+  - "5"
+  - "6"


### PR DESCRIPTION
Based on design from https://github.com/theforeman/foreman-operations-collection/issues/20 -- I have intentionally kept it to Puppet 5 and 6 right now while Puppet 7 support is being developed for Foreman.