### PR TITLE
Add enablement of Ruby 2.7 module for foreman-installer 2.5+

### DIFF
--- a/roles/foreman_repositories/README.md
+++ b/roles/foreman_repositories/README.md
@@ -8,33 +8,33 @@ Role Variables
 
 Optional:
 
-- `foreman_repositories_version`: Version of Foreman to setup repositories for (default: 2.3)
+- `foreman_repositories_version`: Version of Foreman to setup repositories for (default: 2.4)
 - `foreman_repositories_katello_version`: Version of Katello to setup repositories for, set a value for this to configure Katello repositories otherwise no Katello repositories will be configured (default: null)
 
 Example Playbooks
 -----------------
 
-Setup repositories for Foreman 2.3:
+Setup repositories for Foreman 2.4:
 
 ```
 ---
 - hosts: all
   gather_facts: true
   vars:
-    foreman_repositories_version: "2.3"
+    foreman_repositories_version: "2.4"
   roles:
     - foreman_repositories
 ```
 
-Setup repositories for Katello 3.18 and Foreman 2.3:
+Setup repositories for Katello 4.0 and Foreman 2.4:
 
 ```
 ---
 - hosts: all
   gather_facts: true
   vars:
-    foreman_repositories_version: "2.3"
-    foreman_repositories_katello_version: "3.18"
+    foreman_repositories_version: "2.4"
+    foreman_repositories_katello_version: "4.0"
   roles:
     - foreman_repositories
 ```

--- a/roles/foreman_repositories/defaults/main.yml
+++ b/roles/foreman_repositories/defaults/main.yml
@@ -1,2 +1,2 @@
 ---
-foreman_repositories_version: "2.3"
+foreman_repositories_version: "2.4"

--- a/roles/foreman_repositories/molecule/debian/converge.yml
+++ b/roles/foreman_repositories/molecule/debian/converge.yml
@@ -2,5 +2,7 @@
 - name: Converge
   hosts: all
   gather_facts: true
+  vars:
+    foreman_repositories_version: 2.4
   roles:
     - foreman_repositories

--- a/roles/foreman_repositories/molecule/debian/verify.yml
+++ b/roles/foreman_repositories/molecule/debian/verify.yml
@@ -11,5 +11,5 @@
     - name: check foreman repos exists
       assert:
         that:
-          - "'deb http://deb.theforeman.org buster 2.3' in repos['content'] | b64decode"
-          - "'deb http://deb.theforeman.org plugins 2.3' in repos['content'] | b64decode"
+          - "'deb http://deb.theforeman.org buster 2.4' in repos['content'] | b64decode"
+          - "'deb http://deb.theforeman.org plugins 2.4' in repos['content'] | b64decode"

--- a/roles/installer/molecule/default/converge.yml
+++ b/roles/installer/molecule/default/converge.yml
@@ -1,7 +1,7 @@
 ---
 - name: Converge
   hosts: all
-  gather_facts: false
+  gather_facts: true
   vars:
     foreman_installer_scenario: foreman
   roles:

--- a/roles/installer/molecule/default/prepare.yml
+++ b/roles/installer/molecule/default/prepare.yml
@@ -3,6 +3,8 @@
   hosts: all
   gather_facts: true
   become: true
+  vars:
+    foreman_repositories_version: 'nightly'  # Testing Ruby 2.7 enable, switch to 2.5 when released
   roles:
     - puppet_repositories
     - foreman_repositories

--- a/roles/installer/molecule/default/prepare.yml
+++ b/roles/installer/molecule/default/prepare.yml
@@ -3,15 +3,6 @@
   hosts: all
   gather_facts: true
   become: true
-  tasks:
-    - name: 'Setup Foreman latest repository'
-      yum:
-        name: https://yum.theforeman.org/releases/latest/el{{ ansible_distribution_major_version }}/x86_64/foreman-release.rpm
-        disable_gpg_check: true
-        state: present
-
-    - name: 'Setup Puppet 6 Repository'
-      yum:
-        name: https://yum.puppet.com/puppet6-release-el-{{ ansible_distribution_major_version }}.noarch.rpm
-        disable_gpg_check: true
-        state: present
+  roles:
+    - puppet_repositories
+    - foreman_repositories

--- a/roles/installer/tasks/main.yml
+++ b/roles/installer/tasks/main.yml
@@ -4,6 +4,22 @@
     that:
       - foreman_installer_scenario is defined
 
+- when:
+    - ansible_distribution_major_version == '8'
+    - ansible_os_family == 'RedHat'
+  block:
+    - name: Get foreman-installer version
+      dnf:
+        list: foreman-installer
+      register: package_info
+
+    - name: Enable ruby:2.7 module
+      dnf:
+        name: '@ruby:2.7'
+        state: present
+      when:
+        - (package_info.results | map(attribute='version') | max) is version("2.5", ">=")
+
 - name: "Install {{ foreman_installer_package }}"
   package:
     name: "{{ foreman_installer_package }}"


### PR DESCRIPTION
@evgeni Thoughts here? Feels ugly to add yet another variable to represent version, and felt weird to include `foreman_repositories_version` in the `installer` role. I thought about just introducing a shared variable `foreman_version` and `katello_version` to use across any roles.