### PR TITLE
Added environment for foreman-installer

### DIFF
--- a/roles/installer/tasks/main.yml
+++ b/roles/installer/tasks/main.yml
@@ -36,3 +36,6 @@
   register: foreman_installer_run
   changed_when: foreman_installer_run.rc == 2
   failed_when: foreman_installer_run.rc not in [0, 2]
+  environment:
+    LC_ALL: "{{ foreman_installer_locale | default('en_US.UTF-8') }}"
+    LANG: "{{ foreman_installer_locale | default('en_US.UTF-8') }}"


### PR DESCRIPTION
When using this on my systems Ansible was unable to run the ```foreman-installer``` command because in it's environment ```LANG``` and ```LC_ALL``` were set to ```C``` instead of a valid locale.

This commit adds a default locale for both variables, you can override it by setting ```foreman_installer_locale```.