### PR TITLE
Link to Bugzilla in the data directory workaround

### DIFF
--- a/roles/postgresql_upgrade/tasks/main.yml
+++ b/roles/postgresql_upgrade/tasks/main.yml
@@ -35,6 +35,7 @@
         name: postgresql
         state: stopped
 
+    # https://bugzilla.redhat.com/show_bug.cgi?id=1935301
     - name: Update postgresq.conf data directory
       lineinfile:
         path: /var/lib/pgsql/data/postgresql.conf


### PR DESCRIPTION
The removal of that line shouldn't be needed and a bug is open for it. Tracking that inline is always a useful thing.