### PR TITLE
only check if powertools is disabled

### DIFF
--- a/roles/foreman_repositories/tasks/redhat.yml
+++ b/roles/foreman_repositories/tasks/redhat.yml
@@ -43,8 +43,8 @@
       command: dnf module enable pki-core -y
       when: "'pki-core' not in enabled_modules.stdout"
 
-    - name: List disabled repositories
-      command: dnf repolist --disabled
+    - name: Check if powertools repository is disabled
+      command: dnf repolist --disabled powertools
       register: disabled_repos
       changed_when: false
 


### PR DESCRIPTION
otherwise the "if powertools in stdout" condition matches
powertools-source, which we leave disabled