### PR TITLE
don't use apt_key but get_url to fetch the debian key

### DIFF
--- a/roles/foreman_repositories/tasks/debian.yml
+++ b/roles/foreman_repositories/tasks/debian.yml
@@ -1,15 +1,9 @@
 ---
-- name: 'Install GPG package'
-  package:
-    name: 'gpg'
-    state: present
-    update_cache: true
-  tags:
-    - packages
-
 - name: 'Install Foreman GPG key'
-  apt_key:
+  get_url:
     url: https://deb.theforeman.org/foreman.asc
+    dest: /etc/apt/trusted.gpg.d/foreman.asc
+    mode: '0444'
 
 - name: 'Setup Foreman {{ foreman_repositories_version }} repository'
   apt_repository:


### PR DESCRIPTION
apt_key uses apt-key which needs gpg, and apt-key has been deprecated in
Debian