### PR TITLE
Add prepare_realm role

### DIFF
--- a/changelogs/fragments/57-add_prepare_realm_role
+++ b/changelogs/fragments/57-add_prepare_realm_role
@@ -1,0 +1,2 @@
+minor_changes:
+  - Add prepare_realm role to help integrate FreeIPA domain as realm provider in foreman (https://github.com/theforeman/foreman-operations-collection/pull/57)

--- a/roles/prepare_realm/README.md
+++ b/roles/prepare_realm/README.md
@@ -1,0 +1,52 @@
+theforeman.operations.prepare_realm
+===================================
+
+Prepare FreeIPA domain for foreman realm integartion and get keytab
+
+Prerequisites
+-------------
+
+* This role introduce a dependency on the `freeipa.ansible_freeipa` collection. This collection is not an hard requirement for this collection as it is not mandatory for other common operations. Be sure to add manually this collection to your `requirements.yml` file or install it before running this role.
+* The server must be already part of a FreeIPA domain. To automate the FreeIPA client registraion, please see `ipaclient` role documentation of `freeipa.ansible_freeipa` collection.
+
+Role Variables
+--------------
+
+Required:
+
+- `foreman_prepare_realm_freeipa_password`: Password for FreeIPA domain principal, this is required to be set.
+
+Optional:
+
+- `foreman_prepare_realm_freeipa_principal`: FreeIPA domain principal. This principal must have admin rights on the domain. Defaults to `admin`.
+- `foreman_prepare_realm_freeipa_server`: FreeIPA server from where to fetch user keytab. If not provided, `server` value from `/etc/ipa/default.conf` file will be used.
+- `foreman_prepare_realm_freeipa_realm`: FreeIPA realm.If not provided, `realm` value from `/etc/ipa/default.conf` file will be used.
+- `foreman_prepare_realm_user`: FreeIPA user used for Foreman-FreeIPA integration. Defaults to `realm-proxy`.
+- `foreman_prepare_realm_keytab_path`: FreeIPA realm user keytab path. Dfaults to `/etc/foreman-proxy/realm.keytab`.
+- `foreman_prepare_realm_force_keytab_refresh`: Force execution of keytab retrivial. By default keytab is retrivied only if keytab file don't exist. Defaults to `false`.
+
+Example Playbooks
+-----------------
+
+Run the prepare realm with non default admin user and run the installer
+
+```yaml
+- hosts: target-host
+  roles:
+    # Prepare FreeIPA realm integration
+    - role: theforeman.operations.prepare_realm
+      vars:
+        foreman_prepare_realm_freeipa_principal: admin-user
+        foreman_prepare_realm_freeipa_password: changeme
+        foreman_prepare_realm_freeipa_realm: EXAMPLE.COM
+
+    # Run the installer with FreeIPA realm integration options
+    - role: theforeman.operations.installer
+      vars:
+        foreman_installer_options:
+          - "--foreman-proxy-realm true"
+          - "--foreman-proxy-realm-keytab '/etc/foreman-proxy/realm.keytab'"
+          - "--foreman-proxy-realm-principal 'realm-proxy@EXAMPLE.COM'"
+          - "--foreman-proxy-freeipa-remove-dns true"
+```
+

--- a/roles/prepare_realm/defaults/main.yml
+++ b/roles/prepare_realm/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+foreman_prepare_realm_freeipa_user: admin
+foreman_prepare_realm_user: realm-proxy
+foreman_prepare_realm_keytab_path: /etc/foreman-proxy/realm.keytab
+foreman_prepare_realm_force_keytab_refresh: false

--- a/roles/prepare_realm/molecule/default/collections.yml
+++ b/roles/prepare_realm/molecule/default/collections.yml
@@ -1,0 +1,8 @@
+---
+collections:
+  - name: community.docker
+    version: ">=1.2.0,<2"
+  - name: community.general
+    version: ">=2,<3"
+  - name: freeipa.ansible_freeipa
+    version: ">=1.5.1,<2"

--- a/roles/prepare_realm/molecule/default/converge.yml
+++ b/roles/prepare_realm/molecule/default/converge.yml
@@ -1,0 +1,8 @@
+---
+- name: Converge
+  hosts: foreman
+  gather_facts: true
+  roles:
+    - role: prepare_realm
+      vars:
+        foreman_prepare_realm_freeipa_password: changeme

--- a/roles/prepare_realm/molecule/default/molecule.yml
+++ b/roles/prepare_realm/molecule/default/molecule.yml
@@ -1,0 +1,35 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ${DRIVER_NAME:-podman}
+platforms:
+  - name: foreman.example.com
+    groups:
+      - foreman
+    image: centos:8
+    command: /sbin/init
+    tmpfs:
+      - /run
+      - /tmp:exec,mode=777
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+  - name: ipa.example.com
+    groups:
+      - ipa
+    image:
+    command: -U --realm EXAMPLE.COM --admin-password=changeme --ds-password=changeme
+    tmpfs:
+      - /data
+      - /run
+      - /tmp:exec,mode=777
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+provisioner:
+  name: ansible
+verifier:
+  name: ansible
+lint: |
+  set -e
+  yamllint -c ../../.yamllint .
+  ansible-lint .

--- a/roles/prepare_realm/molecule/default/prepare.yml
+++ b/roles/prepare_realm/molecule/default/prepare.yml
@@ -1,0 +1,12 @@
+---
+- name: Prepare
+  hosts: foreman
+  gather_facts: true
+  become: true
+  vars:
+    foreman_repositories_version: 'nightly'  # Testing Ruby 2.7 enable, switch to 2.5 when released
+  roles:
+    - role: foreman_repositories
+    - role: freeipa.ansible_freeipa.ipaclient
+      vars:
+        ipaadmin_password: changeme

--- a/roles/prepare_realm/molecule/default/verify.yml
+++ b/roles/prepare_realm/molecule/default/verify.yml
@@ -1,0 +1,19 @@
+---
+- name: Verify
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Foreman proxy is installed
+      package:
+        name: foreman-proxy
+        state: present
+
+    - name: Keytab file is present
+      stat:
+        path: /etc/foreman-proxy/realm.keytab
+      register: keytab_file
+
+    - name: Assert keytab file exists
+      assert:
+        that:
+          - keytab_file.stat.exists

--- a/roles/prepare_realm/tasks/main.yml
+++ b/roles/prepare_realm/tasks/main.yml
@@ -1,0 +1,99 @@
+---
+- name: Check that necessary variables are defined
+  assert:
+    that:
+      - foreman_prepare_realm_freeipa_password is defined
+
+- name: Install foreman-proxy package
+  package:
+    name: foreman-proxy
+
+- name: Add {{ foreman_prepare_realm_user }} user
+  freeipa.ansible_freeipa.ipauser:
+    ipaadmin_principal: "{{ foreman_prepare_realm_freeipa_principal }}"
+    ipaadmin_password: "{{ foreman_prepare_realm_freeipa_password }}"
+    name: "{{ foreman_prepare_realm_user }}"
+    first: Smart
+    last: Proxy
+
+- name: Add Host Enrollment Password permission
+  freeipa.ansible_freeipa.ipapermission:
+    ipaadmin_principal: "{{ foreman_prepare_realm_freeipa_principal }}"
+    ipaadmin_password: "{{ foreman_prepare_realm_freeipa_password }}"
+    name: Add Host Enrollment Password
+    object_type: host
+    right: add
+    attrs:
+      - userpassword
+
+- name: Add Smart Proxy Host Management privilege
+  freeipa.ansible_freeipa.ipaprivilege:
+    ipaadmin_principal: "{{ foreman_prepare_realm_freeipa_principal }}"
+    ipaadmin_password: "{{ foreman_prepare_realm_freeipa_password }}"
+    name: Smart Proxy Host Management
+    description: Smart Proxy Host Management
+    permission:
+      - "System: Manage Host Enrollment Password"
+      - "System: Manage Host Certificates"
+      - "System: Modify Hosts"
+      - "System: Remove Hosts"
+      - "System: Manage Host Keytab"
+      - "System: Modify Services"
+      - "System: Manage Service Keytab"
+      - "System: Add DNS Entries"
+      - "System: Update DNS Entries"
+      - "System: Remove DNS Entries"
+      - "System: Read DNS Entries"
+      - "Retrieve Certificates from the CA"
+      - "Add Host Enrollment Password"
+
+- name: Add Smart Proxy Manager role
+  freeipa.ansible_freeipa.iparole:
+    ipaadmin_principal: "{{ foreman_prepare_realm_freeipa_principal }}"
+    ipaadmin_password: "{{ foreman_prepare_realm_freeipa_password }}"
+    name: Smart Proxy Host Manager
+    description: Smart Proxy Host Management
+    privilege:
+      - Smart Proxy Host Management
+    user:
+      - "{{ foreman_prepare_realm_user }}"
+
+- name: Check if realm keytab file already exist
+  stat:
+    path: "{{ foreman_prepare_realm_keytab_path }}"
+  register: foreman_prepare_realm_keytab_file
+
+- block:
+    - name: Read /etc/ipa/default.conf file
+      slurp:
+        src: /etc/ipa/default.conf
+      register: ipa_default_conf
+      when:
+        - foreman_prepare_realm_freeipa_server is not defined or foreman_prepare_realm_freeipa_realm is not defined
+
+    - name: Set foreman_prepare_realm_freeipa_server var with value found in /etc/ipa/default.conf
+      set_fact:
+        foreman_prepare_realm_freeipa_server: "{{ (ipa_default_conf['content'] | b64decode | regex_findall('server = .*'))[0].split('=')[1] | trim }}"
+      when:
+        - foreman_prepare_realm_freeipa_server is not defined
+
+    - name: Set foreman_prepare_realm_freeipa_realm var with value found in /etc/ipa/default.conf
+      set_fact:
+        foreman_prepare_realm_freeipa_realm: "{{ (ipa_default_conf['content'] | b64decode | regex_findall('realm = .*'))[0].split('=')[1] | trim }}"
+      when:
+        - foreman_prepare_realm_freeipa_realm is not defined
+
+    - name: Get {{ foreman_prepare_realm_user }}@{{ foreman_prepare_realm_freeipa_realm }} keytab
+      shell: |
+        echo {{ foreman_prepare_realm_freeipa_password }}| kinit {{ foreman_prepare_realm_freeipa_principal }}
+        ipa-getkeytab -p {{ foreman_prepare_realm_user }}@{{ foreman_prepare_realm_freeipa_realm }} -s {{ foreman_prepare_realm_freeipa_server }} -k {{ foreman_prepare_realm_keytab_path }}
+      no_log: true
+  when: not foreman_prepare_realm_keytab_file.stat.exists or foreman_prepare_realm_force_keytab_refresh
+
+- name: Ensure keytab file attributes are correct
+  file:
+    path: "{{ foreman_prepare_realm_keytab_path }}"
+    owner: foreman-proxy
+    group: foreman-proxy
+    mode: '0640'
+    state: file


### PR DESCRIPTION
As discussed in #54 add `prepare_realm` role.

**TODO:**
* [ ] Fail nicely if the FreeIPA collection dependency is not present.
* [ ] Testing (need FreeIPA instance and register foreman server as client)