### PR TITLE
Foreman-installer task made to be async and apt cache fixes

### DIFF
--- a/roles/installer/README.md
+++ b/roles/installer/README.md
@@ -18,6 +18,7 @@ Optional:
 - `foreman_installer_no_colors`: Disables color output from the installer
 - `foreman_installer_command`: Installer command to run, can be used by derivative projects to specify a branded command
 - `foreman_installer_locale`: Locale to run the installer with, this must not be ```C```, defaults to ```en_US.UTF-8```
+- `foreman_installer_timeout`: Time allowed for installer to run before it is assumed failed, defaults to 30m
 
 Example Playbooks
 -----------------

--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -5,3 +5,4 @@ foreman_installer_verbose: true
 foreman_installer_no_colors: false
 foreman_installer_options: []
 foreman_installer_locale: 'en_US.UTF-8'
+foreman_installer_timeout: 1800

--- a/roles/installer/tasks/main.yml
+++ b/roles/installer/tasks/main.yml
@@ -31,7 +31,7 @@
     name: "{{ foreman_installer_package }}"
     state: present
 
-- name: 'Run installer'
+- name: Run installer
   command: >
     {{ foreman_installer_command }}
     --scenario {{ foreman_installer_scenario }}
@@ -39,9 +39,21 @@
     {{ (foreman_installer_no_colors|bool) | ternary("--no-colors", "") }}
     {{ foreman_installer_options | join(' ') }}
     --detailed-exitcodes
-  register: foreman_installer_run
-  changed_when: foreman_installer_run.rc == 2
-  failed_when: foreman_installer_run.rc not in [0, 2]
+  async: "{{ foreman_installer_timeout }}"  # avoid connection timeouts
+  changed_when: false  # async always returns changed, check in async_status instead
+  poll: 0
+  register: async_results
   environment:
     LC_ALL: "{{ foreman_installer_locale }}"
     LANG: "{{ foreman_installer_locale }}"
+
+- name: Check async status for foreman-installer
+  async_status:
+    jid: "{{ async_results.ansible_job_id }}"
+  register: async_poll_results
+  until: async_poll_results.finished
+  changed_when: async_poll_results.rc is defined and async_poll_results.rc == 2
+  failed_when:
+    - (not async_poll_results.finished) or (async_poll_results.rc is defined and async_poll_results.rc not in [0, 2])
+  retries: "{{ ((foreman_installer_timeout | int) / 5) | round | int }}"
+  delay: 5

--- a/roles/puppet_repositories/tasks/debian.yml
+++ b/roles/puppet_repositories/tasks/debian.yml
@@ -1,10 +1,20 @@
 ---
-- name: 'Install GPG package'
+- name: Install GPG package
   package:
-    name: 'gpg'
+    name: gpg
     state: present
     update_cache: true
 
-- name: 'Install Puppet repository'
+- name: Install Puppet repository
   apt:
-    deb: https://apt.puppet.com/puppet{{ foreman_puppet_repositories_version }}-release-{{ ansible_distribution_release }}.deb
+    deb: "https://apt.puppet.com/puppet{{ foreman_puppet_repositories_version }}-release-{{ ansible_distribution_release }}.deb"
+    state: present
+  register: puppet_apt_deb_install
+
+- name: Update apt cache if necessary
+  apt:
+    update_cache: true
+    force_apt_get: true
+  when: puppet_apt_deb_install.changed
+  tags:
+    - skip_ansible_lint  # skip lint since we cannot use handler, and cache must be updated immediately


### PR DESCRIPTION
Foreman-installer is a long running task and is prone to connection timeouts. It's recommended to make these async (ref. https://docs.ansible.com/ansible/latest/user_guide/playbooks_async.html) in order to avoid those connection timeouts. I've tested this and it works well. `changed_when` and `failed_when` continue to work as expected.

I've also included some fixes related to hanging of apt tasks on Ubuntu.