### PR TITLE
pin ansible-lint to pre-6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,6 @@ clean_%: FORCE $(MANIFEST)
 setup: test-setup
 
 test-setup:
-	pip install --upgrade 'pip<20'
 	pip install --upgrade -r requirements-dev.txt
 
 $(MANIFEST): $(NAMESPACE)-$(NAME)-$(VERSION).tar.gz

--- a/requirements-lint.txt
+++ b/requirements-lint.txt
@@ -1,2 +1,2 @@
 flake8
-ansible-lint
+ansible-lint<6


### PR DESCRIPTION
ansible-lint 6 wants ansible-core >= 2.12, which breaks testing with
older ansibles