### PR TITLE
use a regular expression to parse the CN from the cert

### DIFF
--- a/changelogs/fragments/94-subject-regex.yml
+++ b/changelogs/fragments/94-subject-regex.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - cloud_connector role - use a regular expression to parse the CN from the cert

--- a/roles/cloud_connector/tasks/main.yml
+++ b/roles/cloud_connector/tasks/main.yml
@@ -56,7 +56,7 @@
     force_basic_auth: true
     body_format: json
   vars:
-    client_id: "{{ cert_output.stdout.replace('subject= /CN=', '').replace('subject=CN = ', '') }}"
+    client_id: "{{ cert_output.stdout | regex_search('CN\\s?=\\s?([a-z0-9-]+)', '\\1') | first }}"
 
 - name: Configure HTTP proxy
   include: http_proxy.yml


### PR DESCRIPTION
so far we've seen the following output from

    openssl x509 -in /etc/pki/consumer/cert.pem -subject -noout

* `subject= /CN=abcdef12-0123-4567-8901-abcdef012345`
* `subject=CN = abcdef12-0123-4567-8901-abcdef012345`
* `subject=O = 13349708, CN = abcdef12-0123-4567-8901-abcdef012345`

The last one would trip over the old `replace` logic, but can be
properly extracted using a regex.