### PR TITLE
Enable rhcd.service

### DIFF
--- a/roles/cloud_connector/tasks/main.yml
+++ b/roles/cloud_connector/tasks/main.yml
@@ -37,6 +37,7 @@
   service:
     name: rhcd
     state: started
+    enabled: true
 
 - name: Read client ID from CN of consumer
   ansible.builtin.command: openssl x509 -in /etc/pki/consumer/cert.pem -subject -noout


### PR DESCRIPTION
Ensure `rhcd.service` starts after system reboots.

Fix: https://issues.redhat.com/browse/SAT-12447