### PR TITLE
don't mark proxy.conf systemd drop-in word-inaccessible

### DIFF
--- a/changelogs/fragments/bz2169682-world-inaccessible.yml
+++ b/changelogs/fragments/bz2169682-world-inaccessible.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - cloud_connector role - don't mark proxy.conf systemd drop-in word-inaccessible, there is no benefit and systemd warns about this (https://bugzilla.redhat.com/show_bug.cgi?id=2169682)

--- a/roles/cloud_connector/tasks/http_proxy.yml
+++ b/roles/cloud_connector/tasks/http_proxy.yml
@@ -13,6 +13,6 @@
     dest: /etc/systemd/system/rhcd.service.d/proxy.conf
     owner: root
     group: root
-    mode: '0640'
+    mode: '0644'
   notify:
     - Restart rhcd


### PR DESCRIPTION
there is no benefit and systemd warns about this:

    systemd[1]: Configuration file /etc/systemd/system/rhcd.service.d/proxy.conf is marked world-inaccessible.
    This has no effect as configuration data is accessible via APIs without restrictions. Proceeding anyway.