### PR TITLE
Revert "wait for systemd to settle"

### DIFF
--- a/roles/foreman_proxy_certs_generate/molecule/default/prepare.yml
+++ b/roles/foreman_proxy_certs_generate/molecule/default/prepare.yml
@@ -10,15 +10,6 @@
     - foreman_repositories
     - puppet_repositories
   post_tasks:
-    - name: Wait for systemd
-      ansible.builtin.command: systemctl is-system-running --wait # noqa: command-instead-of-module
-      ignore_errors: true
-      changed_when: false
-      register: result
-      until: "'running' in result.stdout or 'degraded' in result.stdout"
-      retries: 12
-      delay: 10
-
     - name: Ensure langpacks on EL8
       ansible.builtin.dnf:
         name: glibc-langpack-en

--- a/roles/installer/molecule/default/prepare.yml
+++ b/roles/installer/molecule/default/prepare.yml
@@ -7,15 +7,6 @@
     - puppet_repositories
     - foreman_repositories
   tasks:
-    - name: Wait for systemd
-      ansible.builtin.command: systemctl is-system-running --wait # noqa: command-instead-of-module
-      ignore_errors: true
-      changed_when: false
-      register: result
-      until: "'running' in result.stdout or 'degraded' in result.stdout"
-      retries: 12
-      delay: 10
-
     - name: Ensure langpacks on EL8
       ansible.builtin.dnf:
         name: glibc-langpack-en

--- a/roles/postgresql_upgrade/molecule/redhat/prepare.yml
+++ b/roles/postgresql_upgrade/molecule/redhat/prepare.yml
@@ -3,15 +3,6 @@
   hosts: all
   gather_facts: true
   tasks:
-    - name: Wait for systemd
-      ansible.builtin.command: systemctl is-system-running --wait # noqa: command-instead-of-module
-      ignore_errors: true
-      changed_when: false
-      register: result
-      until: "'running' in result.stdout or 'degraded' in result.stdout"
-      retries: 12
-      delay: 10
-
     - name: Ensure langpacks on EL8
       ansible.builtin.dnf:
         name: glibc-langpack-en


### PR DESCRIPTION
This reverts commit 0278611043597f94f295dc912ace149bc9c4e6d6.

This was needed for https://bugzilla.redhat.com/show_bug.cgi?id=2174645 which is now fixed in the latest CentOS Stream 8 container builds.