### PR TITLE
update default Python versions for CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.9"
+          python-version: "3.11"
       - name: Install dependencies
         run: make doc-setup
       - name: Build docs

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,6 +65,21 @@ jobs:
           name: docs-html
           path: docs/_build/html/
 
+  galaxy-importer:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+          cache: 'pip'
+          cache-dependency-path: '**/requirements*.txt'
+      - name: Install dependencies
+        run: pip install --upgrade py galaxy-importer
+      - name: Run galaxy-importer
+        run: make galaxy-importer
+
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,6 @@ jobs:
         python:
           - "3.10"
         ansible:
-          - stable-2.11
           - stable-2.12
           - stable-2.13
           - stable-2.14
@@ -24,19 +23,9 @@ jobs:
           - devel
         include:
           - python: "3.8"
-            ansible: "stable-2.9"
-          - python: "3.8"
-            ansible: "stable-2.10"
-          - python: "2.7"
-            ansible: "stable-2.11"
-          - python: "3.5"
-            ansible: "stable-2.11"
-          - python: "3.6"
-            ansible: "stable-2.11"
-          - python: "3.7"
-            ansible: "stable-2.11"
+            ansible: "stable-2.12"
           - python: "3.9"
-            ansible: "stable-2.11"
+            ansible: "stable-2.13"
           - python: "3.11"
             ansible: "devel"
     steps:
@@ -55,7 +44,6 @@ jobs:
         run: make test-setup
       - name: Run sanity tests
         run: make SANITY_OPTS="--local" sanity
-        if: matrix.ansible != 'stable-2.9' && matrix.ansible != 'stable-2.10' && matrix.ansible != 'stable-2.11'
 
   docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         python:
-          - "3.9"
+          - "3.10"
         ansible:
           - stable-2.11
           - stable-2.12
@@ -35,8 +35,8 @@ jobs:
             ansible: "stable-2.11"
           - python: "3.7"
             ansible: "stable-2.11"
-          - python: "3.10"
-            ansible: "devel"
+          - python: "3.9"
+            ansible: "stable-2.11"
           - python: "3.11"
             ansible: "devel"
     steps:
@@ -64,7 +64,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.9"
+          python-version: "3.11"
           cache: 'pip'
           cache-dependency-path: '**/requirements*.txt'
       - name: Install dependencies
@@ -84,7 +84,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.9"
+          python-version: "3.11"
           cache: 'pip'
           cache-dependency-path: '**/requirements*.txt'
       - name: Install dependencies
@@ -105,9 +105,8 @@ jobs:
       fail-fast: false
       matrix:
         python:
-          - "3.9"
+          - "3.10"
         ansible:
-          - stable-2.11
           - stable-2.12
           - stable-2.13
           - stable-2.14
@@ -118,6 +117,8 @@ jobs:
             ansible: "stable-2.9"
           - python: "3.8"
             ansible: "stable-2.10"
+          - python: "3.9"
+            ansible: "stable-2.11"
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python
@@ -143,7 +144,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.9"
+          python-version: "3.11"
           cache: 'pip'
           cache-dependency-path: '**/requirements*.txt'
       - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.9"
+          python-version: "3.11"
       - name: Install Ansible
         run: pip install --upgrade ansible
       - name: Build Ansible Collection

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,8 @@ info:
 lint: $(MANIFEST)
 	yamllint -f parsable roles
 	ansible-lint -v roles/*
+
+galaxy-importer: $(MANIFEST)
 	GALAXY_IMPORTER_CONFIG=tests/galaxy-importer.cfg python -m galaxy_importer.main $(NAMESPACE)-$(NAME)-$(VERSION).tar.gz
 
 sanity: $(MANIFEST)

--- a/requirements-lint.txt
+++ b/requirements-lint.txt
@@ -1,4 +1,3 @@
 flake8<4
 yamllint
 ansible-lint>=6.1.0
-galaxy-importer


### PR DESCRIPTION
- run tests by default with 3.10, as core dropped 3.9 support in devel
- add 3.9 as an additional test with core 2.11
- run all other steps with 3.11, as that's the latest supported one