### PR TITLE
Restart rhcd after writing out config file

### DIFF
--- a/roles/cloud_connector/tasks/main.yml
+++ b/roles/cloud_connector/tasks/main.yml
@@ -21,6 +21,8 @@
     owner: root
     group: root
     mode: '0640'
+  notify:
+    - Restart rhcd
 
 - name: Create rhcd worker
   ansible.builtin.copy:


### PR DESCRIPTION
Restart rhcd.service after writing
`/etc/rhc/workers/foreman_rh_cloud.toml`. This ensures that rhcd.service reads the latest values from that file.

Fix: https://issues.redhat.com/browse/SAT-23989