### PR TITLE
don't lint as part of the molecule run

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -144,7 +144,7 @@ jobs:
       - name: Install dependencies
         run: make test-setup
       - name: Install Ansible 2.9 compatible molecule and Jinja
-        run: pip install --upgrade 'molecule[docker,lint]<4.0' 'Jinja2<3.1'
+        run: pip install --upgrade 'molecule[docker]<4.0' 'Jinja2<3.1'
         if: matrix.ansible == 'v2.9.17'
       - name: Run tests
         env:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,8 +6,6 @@ cryptography<3.1; python_version < '3.6'
 pylint==2.6.0; python_version >= '3.6'
 voluptuous==0.12.1 # from https://github.com/ansible/ansible/raw/devel/test/lib/ansible_test/_data/requirements/sanity.validate-modules.txt
 yamllint
-molecule[docker,lint]
+molecule[docker]
 molecule-plugins[docker]; python_version >= '3.9'
 ansible-compat<4; python_version >= '3.6' # https://github.com/ansible-community/molecule/issues/3903
-ansible-lint; python_version >= '3.9'
-ansible-lint<6.12.0; python_version < '3.9'

--- a/roles/backup/molecule/debian/molecule.yml
+++ b/roles/backup/molecule/debian/molecule.yml
@@ -10,7 +10,3 @@ provisioner:
   name: ansible
 verifier:
   name: ansible
-lint: |
-  set -e
-  yamllint -c ../../.yamllint .
-  YAMLLINT_CONFIG_FILE=../../.yamllint ansible-lint .

--- a/roles/backup/molecule/redhat/molecule.yml
+++ b/roles/backup/molecule/redhat/molecule.yml
@@ -16,7 +16,3 @@ provisioner:
   name: ansible
 verifier:
   name: ansible
-lint: |
-  set -e
-  yamllint -c ../../.yamllint .
-  YAMLLINT_CONFIG_FILE=../../.yamllint ansible-lint .

--- a/roles/foreman_proxy_certs_generate/molecule/default/molecule.yml
+++ b/roles/foreman_proxy_certs_generate/molecule/default/molecule.yml
@@ -16,7 +16,3 @@ provisioner:
   name: ansible
 verifier:
   name: ansible
-lint: |
-  set -e
-  yamllint -c ../../.yamllint .
-  YAMLLINT_CONFIG_FILE=../../.yamllint ansible-lint .

--- a/roles/foreman_repositories/molecule/debian/molecule.yml
+++ b/roles/foreman_repositories/molecule/debian/molecule.yml
@@ -10,7 +10,3 @@ provisioner:
   name: ansible
 verifier:
   name: ansible
-lint: |
-  set -e
-  yamllint -c ../../.yamllint .
-  YAMLLINT_CONFIG_FILE=../../.yamllint ansible-lint .

--- a/roles/foreman_repositories/molecule/redhat/molecule.yml
+++ b/roles/foreman_repositories/molecule/redhat/molecule.yml
@@ -16,7 +16,3 @@ provisioner:
   name: ansible
 verifier:
   name: ansible
-lint: |
-  set -e
-  yamllint -c ../../.yamllint .
-  YAMLLINT_CONFIG_FILE=../../.yamllint ansible-lint .

--- a/roles/installer/molecule/default/molecule.yml
+++ b/roles/installer/molecule/default/molecule.yml
@@ -16,7 +16,3 @@ provisioner:
   name: ansible
 verifier:
   name: ansible
-lint: |
-  set -e
-  yamllint -c ../../.yamllint .
-  YAMLLINT_CONFIG_FILE=../../.yamllint ansible-lint .

--- a/roles/metrics/molecule/debian/molecule.yml
+++ b/roles/metrics/molecule/debian/molecule.yml
@@ -10,7 +10,3 @@ provisioner:
   name: ansible
 verifier:
   name: ansible
-lint: |
-  set -e
-  yamllint -c ../../.yamllint .
-  YAMLLINT_CONFIG_FILE=../../.yamllint ansible-lint .

--- a/roles/metrics/molecule/redhat/molecule.yml
+++ b/roles/metrics/molecule/redhat/molecule.yml
@@ -16,7 +16,3 @@ provisioner:
   name: ansible
 verifier:
   name: ansible
-lint: |
-  set -e
-  yamllint -c ../../.yamllint .
-  YAMLLINT_CONFIG_FILE=../../.yamllint ansible-lint .

--- a/roles/puppet_repositories/molecule/debian/molecule.yml
+++ b/roles/puppet_repositories/molecule/debian/molecule.yml
@@ -10,7 +10,3 @@ provisioner:
   name: ansible
 verifier:
   name: ansible
-lint: |
-  set -e
-  yamllint -c ../../.yamllint .
-  YAMLLINT_CONFIG_FILE=../../.yamllint ansible-lint .

--- a/roles/puppet_repositories/molecule/redhat/molecule.yml
+++ b/roles/puppet_repositories/molecule/redhat/molecule.yml
@@ -16,7 +16,3 @@ provisioner:
   name: ansible
 verifier:
   name: ansible
-lint: |
-  set -e
-  yamllint -c ../../.yamllint .
-  YAMLLINT_CONFIG_FILE=../../.yamllint ansible-lint .


### PR DESCRIPTION
we have a dedicated step for linting in CI and as we use older molecule on certain targets, it limits the linter version, which yields bad results