### PR TITLE
Only disable `foreman-protector` plugin when running on RHEL

### DIFF
--- a/roles/metrics/tasks/grafana.yml
+++ b/roles/metrics/tasks/grafana.yml
@@ -5,7 +5,7 @@
       - grafana
       - grafana-pcp
     state: present
-    disable_plugin: foreman-protector
+    disable_plugin: "{{ 'foreman-protector' if ansible_os_family == 'RedHat' else omit }}"
 
 - name: Add PCP plugin to Grafana
   ansible.builtin.copy:


### PR DESCRIPTION
Like it's done in the main PCP playbook.