### PR TITLE
allow disabling pulling /metrics endpoint

### DIFF
--- a/changelogs/fragments/metrics-optional-endpoint.yml
+++ b/changelogs/fragments/metrics-optional-endpoint.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - metrics role - allow disabling pulling the OpenMetrics endpoint

--- a/roles/metrics/README.md
+++ b/roles/metrics/README.md
@@ -8,7 +8,7 @@ This role is heavily based on the [performancecopilot.metrics](https://github.co
 Role Variables
 --------------
 
-* `foreman_metrics_url`: The URL of the OpenMetrics endpoint of Foreman, defaults to `https://{{ ansible_fqdn | default('localhost') }}/metrics`.
+* `foreman_metrics_url`: The URL of the OpenMetrics endpoint of Foreman, defaults to `https://{{ ansible_fqdn | default('localhost') }}/metrics`. Set to an empty string (`''`) to disable fetching metrics from Foreman.
 * `foreman_metrics_pcp_optional_agents`: The optional PCP agents to enable, defaults to `[apache, openmetrics, postgresql, redis]`.
 * `foreman_metrics_grafana_enabled`: Whether or not Grafana should be installed and configured on the system, defaults to `true` on Red Hat family systems, and to `false` otherwise.
 * `foreman_metrics_grafana_pmproxy_url`: The URL of the `pmproxy` service to be used as the Grafana datasource, defaults to `http://{{ ansible_fqdn | default('localhost') }}:44322`.

--- a/roles/metrics/tasks/main.yml
+++ b/roles/metrics/tasks/main.yml
@@ -30,6 +30,9 @@
     dest: /var/lib/pcp/pmdas/openmetrics/config.d/foreman.url
     content: "{{ foreman_metrics_url }}"
     mode: '0644'
+  when:
+    - foreman_metrics_url is defined
+    - foreman_metrics_url != ''
   notify:
     - Restart pmcd
     - Restart pmproxy


### PR DESCRIPTION
useful when you want to deploy metrics for a proxy only setup
