### PR TITLE
Fixes SAT-34224 - Remove protocol from NO_PROXY var

### DIFF
--- a/roles/cloud_connector/templates/proxy.conf.j2
+++ b/roles/cloud_connector/templates/proxy.conf.j2
@@ -1,3 +1,3 @@
 [Service]
 Environment=HTTPS_PROXY={{ foreman_cloud_connector_http_proxy }}
-Environment=NO_PROXY={{ foreman_cloud_connector_url }}
+Environment=NO_PROXY={{ foreman_cloud_connector_url | ansible.builtin.urlsplit('hostname') }}


### PR DESCRIPTION
Right now, if the Cloud Connector role would be executed on a foreman\satellite instance, that has http_proxy configured, then the `/etc/systemd/system/rhcd.service.d/proxy.conf` file ends up having the following config

```
# cat /etc/systemd/system/rhcd.service.d/proxy.conf
[Service]
Environment=HTTPS_PROXY=http://proxy.example.com:3128
Environment=NO_PROXY=https://mysat.example.com
```

But as far as I could find out, `NO_PROXY` variable is not expected to be defined with an http or https protocol. I believe it accepts individual domains, FQDNs, or network addresses ( single or as command-separated values ).

One of the users ran into an SSL issue as their proxy does not allow any other communication to be done through it except for a few selected URLs. When rhc was trying to call the API of satellite \foreman, it was still using the proxy to do that and running into SSL issues, and that raised suspicion about NO_PROXY variable. 

Applying the fix from this PR, helped get past that issue.  And now, the file would look something like this:

```
# cat /etc/systemd/system/rhcd.service.d/proxy.conf
[Service]
Environment=HTTPS_PROXY=http://proxy.example.com:3128
Environment=NO_PROXY=mysat.example.com
```