### PR TITLE
Update default Puppet version to 8

### DIFF
--- a/roles/foreman_proxy_certs_generate/molecule/default/prepare.yml
+++ b/roles/foreman_proxy_certs_generate/molecule/default/prepare.yml
@@ -10,8 +10,8 @@
       ansible.builtin.include_role:
         name: foreman_repositories
       vars:
-        foreman_repositories_version: "3.10"
-        foreman_repositories_katello_version: "4.12"
+        foreman_repositories_version: "3.16"
+        foreman_repositories_katello_version: "4.18"
     - name: Ensure langpacks on EL8
       ansible.builtin.dnf:
         name: glibc-langpack-en

--- a/roles/installer/molecule/default/prepare.yml
+++ b/roles/installer/molecule/default/prepare.yml
@@ -10,7 +10,7 @@
       ansible.builtin.include_role:
         name: foreman_repositories
       vars:
-        foreman_repositories_version: "3.10"
+        foreman_repositories_version: "3.16"
     - name: Ensure langpacks on EL8
       ansible.builtin.dnf:
         name: glibc-langpack-en

--- a/roles/installer/molecule/default/prepare.yml
+++ b/roles/installer/molecule/default/prepare.yml
@@ -16,3 +16,11 @@
         name: glibc-langpack-en
         state: present
       when: ansible_facts['os_family'] == 'RedHat'
+    - name: Install installer
+      ansible.builtin.package:
+        name: foreman-installer
+        state: present
+    - name: Disable force_fact_upload
+      ansible.builtin.lineinfile:
+        path: /etc/foreman-installer/custom-hiera.yaml
+        line: 'foreman::register::force_fact_upload: false'

--- a/roles/puppet_repositories/README.md
+++ b/roles/puppet_repositories/README.md
@@ -8,12 +8,12 @@ Role Variables
 
 Optional:
 
-- `foreman_puppet_repositories_version`: Version of Puppet to setup repositories for (default: 7)
+- `foreman_puppet_repositories_version`: Version of Puppet to setup repositories for (default: 8)
 
 Example Playbooks
 -----------------
 
-Setup repositories for default Puppet 7 for use by installer:
+Setup repositories for default Puppet 8 for use by installer:
 
 ```yaml
 ---
@@ -23,14 +23,14 @@ Setup repositories for default Puppet 7 for use by installer:
     - puppet_repositories
 ```
 
-Setup repositories for Puppet 6:
+Setup repositories for Puppet 7:
 
 ```yaml
 ---
 - hosts: all
   gather_facts: true
   vars:
-    foreman_puppet_repositories_version: 6
+    foreman_puppet_repositories_version: 7
   roles:
     - puppet_repositories
 ```

--- a/roles/puppet_repositories/defaults/main.yml
+++ b/roles/puppet_repositories/defaults/main.yml
@@ -1,2 +1,2 @@
 ---
-foreman_puppet_repositories_version: 7
+foreman_puppet_repositories_version: 8

--- a/roles/puppet_repositories/molecule/debian/converge.yml
+++ b/roles/puppet_repositories/molecule/debian/converge.yml
@@ -3,6 +3,6 @@
   hosts: all
   gather_facts: true
   vars:
-    foreman_puppet_repositories_version: 7
+    foreman_puppet_repositories_version: 8
   roles:
     - puppet_repositories

--- a/roles/puppet_repositories/molecule/debian/prepare.yml
+++ b/roles/puppet_repositories/molecule/debian/prepare.yml
@@ -3,8 +3,8 @@
   hosts: all
   gather_facts: true
   tasks:
-    - name: Configure Puppet 6 repositories
+    - name: Configure Puppet 7 repositories
       ansible.builtin.include_role:
         name: puppet_repositories
       vars:
-        foreman_puppet_repositories_version: 6
+        foreman_puppet_repositories_version: 7

--- a/roles/puppet_repositories/molecule/debian/verify.yml
+++ b/roles/puppet_repositories/molecule/debian/verify.yml
@@ -3,17 +3,17 @@
   hosts: all
   gather_facts: false
   tasks:
-    - name: Ensure puppet5-release package is absent
-      ansible.builtin.package:
-        name: puppet5-release
-        state: absent
-
     - name: Ensure puppet6-release package is absent
       ansible.builtin.package:
         name: puppet6-release
         state: absent
 
-    - name: Ensure puppet7-release package is present
+    - name: Ensure puppet7-release package is absent
       ansible.builtin.package:
         name: puppet7-release
+        state: absent
+
+    - name: Ensure puppet8-release package is present
+      ansible.builtin.package:
+        name: puppet8-release
         state: present

--- a/roles/puppet_repositories/molecule/redhat/converge.yml
+++ b/roles/puppet_repositories/molecule/redhat/converge.yml
@@ -3,6 +3,6 @@
   hosts: all
   gather_facts: true
   vars:
-    foreman_puppet_repositories_version: 7
+    foreman_puppet_repositories_version: 8
   roles:
     - puppet_repositories

--- a/roles/puppet_repositories/molecule/redhat/prepare.yml
+++ b/roles/puppet_repositories/molecule/redhat/prepare.yml
@@ -3,8 +3,8 @@
   hosts: all
   gather_facts: true
   tasks:
-    - name: Configure Puppet 6 repositories
+    - name: Configure Puppet 7 repositories
       ansible.builtin.include_role:
         name: puppet_repositories
       vars:
-        foreman_puppet_repositories_version: 6
+        foreman_puppet_repositories_version: 7

--- a/roles/puppet_repositories/molecule/redhat/verify.yml
+++ b/roles/puppet_repositories/molecule/redhat/verify.yml
@@ -3,17 +3,17 @@
   hosts: all
   gather_facts: false
   tasks:
-    - name: Ensure puppet5-release RPM is absent
-      ansible.builtin.package:
-        name: puppet5-release
-        state: absent
-
     - name: Ensure puppet6-release RPM is absent
       ansible.builtin.package:
         name: puppet6-release
         state: absent
 
-    - name: Ensure puppet7-release RPM is installed
+    - name: Ensure puppet7-release RPM is absent
       ansible.builtin.package:
         name: puppet7-release
+        state: absent
+
+    - name: Ensure puppet8-release RPM is present
+      ansible.builtin.package:
+        name: puppet8-release
         state: present


### PR DESCRIPTION
Forklift devel boxes are failing with:
```bash
TASK [foreman_installer_devel_scenario : Install gems to rebuild the kafo module cache] *************************************************************************************************************************
fatal: [ip-10-0-168-187.rhos-01.prod.psi.rdu2.redhat.com]: FAILED! => changed=false
  cmd: /opt/puppetlabs/puppet/bin/gem install --norc --user-install --no-document puppet-strings
  msg: |-
    WARNING:  You don't have /root/.gem/ruby/2.7.0/bin in your PATH,
              gem executables will not run.
    ERROR:  Error installing puppet-strings:
            The last version of fast_gettext (>= 2.1, < 4) to support your Ruby & RubyGems was 2.4.0. Try installing it with `gem install fast_gettext -v 2.4.0` and then running the current command again
            fast_gettext requires Ruby version >= 3.0.0. The current ruby version is 2.7.8.225.
  rc: 1
  stderr: |-
    WARNING:  You don't have /root/.gem/ruby/2.7.0/bin in your PATH,
              gem executables will not run.
    ERROR:  Error installing puppet-strings:
            The last version of fast_gettext (>= 2.1, < 4) to support your Ruby & RubyGems was 2.4.0. Try installing it with `gem install fast_gettext -v 2.4.0` and then running the current command again
            fast_gettext requires Ruby version >= 3.0.0. The current ruby version is 2.7.8.225.
  stderr_lines: <omitted>
  stdout: |-
    Successfully installed yard-0.9.37
    Successfully installed rgen-0.10.2
    Successfully installed getoptlong-0.2.1
  stdout_lines: <omitted>
```
If you change the puppet repo version to 8 it works fine.