### PR TITLE
Remove rhel-8 target from Packit config

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -28,7 +28,6 @@ jobs:
   - job: copr_build
     trigger: pull_request
     targets:
-      - rhel-8
       - rhel-9
     module_hotfixes: true
 


### PR DESCRIPTION
This PR removes the obsolete rhel-8 target from the Packit config

🤖 Generated with [Claude Code](https://claude.com/claude-code)