### PR TITLE
Refactor to use ansible_facts dict instead of top-level facts

### DIFF
--- a/roles/foreman_repositories/tasks/debian.yml
+++ b/roles/foreman_repositories/tasks/debian.yml
@@ -7,7 +7,7 @@
 
 - name: 'Setup repository for Foreman {{ foreman_repositories_version }}'
   ansible.builtin.apt_repository:
-    repo: deb http://deb.theforeman.org {{ ansible_distribution_release }} {{ foreman_repositories_version }}
+    repo: deb http://deb.theforeman.org {{ ansible_facts['distribution_release'] }} {{ foreman_repositories_version }}
     state: present
 
 - name: 'Setup repository for Foreman Plugins {{ foreman_repositories_version }}'

--- a/roles/foreman_repositories/tasks/main.yml
+++ b/roles/foreman_repositories/tasks/main.yml
@@ -6,4 +6,4 @@
     fail_msg: foreman_repositories_version must be defined for this role to work
 
 - name: Load OS specific repository tasks
-  ansible.builtin.include_tasks: "{{ ansible_os_family | lower }}.yml"
+  ansible.builtin.include_tasks: "{{ ansible_facts['os_family'] | lower }}.yml"

--- a/roles/foreman_repositories/tasks/redhat.yml
+++ b/roles/foreman_repositories/tasks/redhat.yml
@@ -1,7 +1,7 @@
 ---
 - name: 'Setup repository for Foreman {{ foreman_repositories_version }}'
   ansible.builtin.package:
-    name: https://yum.theforeman.org/releases/{{ foreman_repositories_version }}/el{{ ansible_distribution_major_version }}/x86_64/foreman-release.rpm
+    name: https://yum.theforeman.org/releases/{{ foreman_repositories_version }}/el{{ ansible_facts['distribution_major_version'] }}/x86_64/foreman-release.rpm
     disable_gpg_check: true
     state: present
   tags:
@@ -9,7 +9,7 @@
 
 - name: 'Setup repository for Katello {{ foreman_repositories_katello_version }}'
   ansible.builtin.package:
-    name: https://yum.theforeman.org/katello/{{ foreman_repositories_katello_version }}/katello/el{{ ansible_distribution_major_version }}/x86_64/katello-repos-latest.rpm
+    name: https://yum.theforeman.org/katello/{{ foreman_repositories_katello_version }}/katello/el{{ ansible_facts['distribution_major_version'] }}/x86_64/katello-repos-latest.rpm
     disable_gpg_check: true
     state: present
   tags:
@@ -20,14 +20,14 @@
 - name: 'Enable modules on EL8'
   ansible.builtin.include_tasks: redhat-modules.yml
   when:
-    - ansible_distribution_major_version == '8'
+    - ansible_facts['distribution_major_version'] == '8'
 
 - name: Enable powertools for Katello
   when:
     - foreman_repositories_katello_version is defined
     - foreman_repositories_katello_version != 'nightly'
     - foreman_repositories_katello_version is version('4.10', '<')
-    - ansible_distribution_major_version == '8'
+    - ansible_facts['distribution_major_version'] == '8'
   block:
     - name: Install dnf-config-manager
       ansible.builtin.package:
@@ -45,4 +45,4 @@
       changed_when: __foreman_dnf_set_enabled.rc is defined and __foreman_dnf_set_enabled.rc == '0'
       when:
         - "'powertools' in __foreman_disabled_repos.stdout"
-        - ansible_distribution != 'RedHat'
+        - ansible_facts['distribution'] != 'RedHat'

--- a/roles/metrics/README.md
+++ b/roles/metrics/README.md
@@ -8,10 +8,10 @@ This role is heavily based on the [performancecopilot.metrics](https://github.co
 Role Variables
 --------------
 
-* `foreman_metrics_url`: The URL of the OpenMetrics endpoint of Foreman, defaults to `https://{{ ansible_fqdn | default('localhost') }}/metrics`. Set to an empty string (`''`) to disable fetching metrics from Foreman.
+* `foreman_metrics_url`: The URL of the OpenMetrics endpoint of Foreman, defaults to `https://{{ ansible_facts['fqdn'] | default('localhost') }}/metrics`. Set to an empty string (`''`) to disable fetching metrics from Foreman.
 * `foreman_metrics_pcp_optional_agents`: The optional PCP agents to enable, defaults to `[apache, openmetrics, postgresql, redis]`.
 * `foreman_metrics_grafana_enabled`: Whether or not Grafana should be installed and configured on the system, defaults to `true` on Red Hat family systems, and to `false` otherwise.
-* `foreman_metrics_grafana_pmproxy_url`: The URL of the `pmproxy` service to be used as the Grafana datasource, defaults to `http://{{ ansible_fqdn | default('localhost') }}:44322`.
+* `foreman_metrics_grafana_pmproxy_url`: The URL of the `pmproxy` service to be used as the Grafana datasource, defaults to `http://{{ ansible_facts['fqdn'] | default('localhost') }}:44322`.
 
 Example Playbooks
 -----------------

--- a/roles/metrics/defaults/main.yml
+++ b/roles/metrics/defaults/main.yml
@@ -1,12 +1,12 @@
 ---
-foreman_metrics_url: "https://{{ ansible_fqdn | default('localhost') }}/metrics"
-foreman_metrics_pcp_additional_packages: "{{ ['pcp-system-tools'] if ansible_os_family == 'RedHat' else ['python3-psycopg2', 'python3-requests'] }}"
+foreman_metrics_url: "https://{{ ansible_facts['fqdn'] | default('localhost') }}/metrics"
+foreman_metrics_pcp_additional_packages: "{{ ['pcp-system-tools'] if ansible_facts['os_family'] == 'RedHat' else ['python3-psycopg2', 'python3-requests'] }}"
 foreman_metrics_pcp_optional_agents:
   - apache
   - openmetrics
   - postgresql
   - redis
 foreman_metrics_pcp_optional_agent_packages_redhat: "{{ foreman_metrics_pcp_optional_agents | map('regex_replace', '^', 'pcp-pmda-') }}"
-foreman_metrics_pcp_optional_agent_packages: "{{ foreman_metrics_pcp_optional_agent_packages_redhat if ansible_os_family == 'RedHat' else [] }}"
-foreman_metrics_grafana_enabled: "{{ ansible_os_family == 'RedHat' }}"
-foreman_metrics_grafana_pmproxy_url: "http://{{ ansible_fqdn | default('localhost') }}:44322"
+foreman_metrics_pcp_optional_agent_packages: "{{ foreman_metrics_pcp_optional_agent_packages_redhat if ansible_facts['os_family'] == 'RedHat' else [] }}"
+foreman_metrics_grafana_enabled: "{{ ansible_facts['os_family'] == 'RedHat' }}"
+foreman_metrics_grafana_pmproxy_url: "http://{{ ansible_facts['fqdn'] | default('localhost') }}:44322"

--- a/roles/metrics/tasks/grafana.yml
+++ b/roles/metrics/tasks/grafana.yml
@@ -5,7 +5,7 @@
       - grafana
       - grafana-pcp
     state: present
-    disable_plugin: "{{ 'foreman-protector' if ansible_os_family == 'RedHat' else omit }}"
+    disable_plugin: "{{ 'foreman-protector' if ansible_facts['os_family'] == 'RedHat' else omit }}"
 
 - name: Add PCP plugin to Grafana
   ansible.builtin.copy:

--- a/roles/metrics/tasks/main.yml
+++ b/roles/metrics/tasks/main.yml
@@ -3,7 +3,7 @@
   ansible.builtin.package:
     name: "{{ ['foreman-pcp', 'pcp'] + foreman_metrics_pcp_additional_packages + foreman_metrics_pcp_optional_agent_packages }}"
     state: present
-    disable_plugin: "{{ 'foreman-protector' if ansible_os_family == 'RedHat' else omit }}"
+    disable_plugin: "{{ 'foreman-protector' if ansible_facts['os_family'] == 'RedHat' else omit }}"
 
 - name: Read pmcd.conf
   ansible.builtin.slurp:

--- a/roles/puppet_repositories/tasks/debian.yml
+++ b/roles/puppet_repositories/tasks/debian.yml
@@ -7,7 +7,7 @@
 
 - name: Install Puppet repository
   ansible.builtin.apt:
-    deb: "https://apt.puppet.com/puppet{{ foreman_puppet_repositories_version }}-release-{{ ansible_distribution_release }}.deb"
+    deb: "https://apt.puppet.com/puppet{{ foreman_puppet_repositories_version }}-release-{{ ansible_facts['distribution_release'] }}.deb"
     state: present
   register: __foreman_puppet_apt_deb_install
 

--- a/roles/puppet_repositories/tasks/main.yml
+++ b/roles/puppet_repositories/tasks/main.yml
@@ -5,5 +5,5 @@
     state: absent
   loop: "{{ foreman_puppet_repositories_supported_versions | difference([foreman_puppet_repositories_version | string]) }}"
 
-- name: 'Include {{ ansible_os_family }}'
-  ansible.builtin.include_tasks: '{{ ansible_os_family | lower }}.yml'
+- name: Load OS specific repository tasks
+  ansible.builtin.include_tasks: "{{ ansible_facts['os_family'] | lower }}.yml"

--- a/roles/puppet_repositories/tasks/redhat.yml
+++ b/roles/puppet_repositories/tasks/redhat.yml
@@ -1,6 +1,6 @@
 ---
 - name: 'Setup Puppet repository'
   ansible.builtin.package:
-    name: https://yum.puppet.com/puppet{{ foreman_puppet_repositories_version }}-release-el-{{ ansible_distribution_major_version }}.noarch.rpm
+    name: https://yum.puppet.com/puppet{{ foreman_puppet_repositories_version }}-release-el-{{ ansible_facts['distribution_major_version'] }}.noarch.rpm
     disable_gpg_check: true
     state: present


### PR DESCRIPTION
Replace deprecated top-level ansible fact variables with the new ansible_facts dictionary format to resolve deprecation warnings in ansible-core 2.20 and prepare for compatibility with 2.24+.