### PR TITLE
Update testing matrix: default Python 3.13, add Ansible 2.21

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: "3.13"
       - name: Install dependencies
         run: make doc-setup
       - name: Build docs

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,6 +27,7 @@ jobs:
           - stable-2.18
           - stable-2.19
           - stable-2.20
+          - stable-2.21
           - devel
 
     runs-on: ubuntu-24.04
@@ -50,7 +51,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: "3.13"
           cache: 'pip'
           cache-dependency-path: '**/requirements*.txt'
       - name: Install dependencies
@@ -70,7 +71,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: "3.13"
           cache: 'pip'
           cache-dependency-path: '**/requirements*.txt'
       - name: Install dependencies
@@ -106,14 +107,12 @@ jobs:
       fail-fast: false
       matrix:
         python:
-          - "3.12"
+          - "3.13"
         ansible:
-          - stable-2.15
-          - stable-2.16
-          - stable-2.17
           - stable-2.18
           - stable-2.19
           - stable-2.20
+          - stable-2.21
           - devel
         include:
           - python: "3.9"
@@ -122,6 +121,12 @@ jobs:
             ansible: "stable-2.13"
           - python: "3.11"
             ansible: "stable-2.14"
+          - python: "3.12"
+            ansible: "stable-2.15"
+          - python: "3.12"
+            ansible: "stable-2.16"
+          - python: "3.12"
+            ansible: "stable-2.17"
     steps:
       - uses: actions/checkout@v6
       - name: Set up Python
@@ -144,7 +149,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: "3.13"
           cache: 'pip'
           cache-dependency-path: '**/requirements*.txt'
       - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: "3.13"
       - name: Install Ansible
         run: pip install --upgrade ansible py antsibull-changelog
       - name: Build Ansible Collection


### PR DESCRIPTION
Ansible 2.17 and older remain on 3.12, as they do not officially support 3.13