### PR TITLE
Refactor openvox_repositories to use ansible_facts dict

### DIFF
--- a/roles/openvox_repositories/tasks/debian.yml
+++ b/roles/openvox_repositories/tasks/debian.yml
@@ -7,10 +7,10 @@
 
 - name: Install OpenVox repository
   ansible.builtin.apt:
-    deb: "https://apt.voxpupuli.org/openvox{{ foreman_openvox_repositories_version }}-release-{{ ansible_distribution | lower }}{{ __foreman_openvox_distribution_version }}.deb"
+    deb: "https://apt.voxpupuli.org/openvox{{ foreman_openvox_repositories_version }}-release-{{ ansible_facts['distribution'] | lower }}{{ __foreman_openvox_distribution_version }}.deb"
     state: present
   vars:
-    __foreman_openvox_distribution_version: "{{ (ansible_distribution == 'Ubuntu') | ternary(ansible_distribution_version, ansible_distribution_major_version) }}"
+    __foreman_openvox_distribution_version: "{{ (ansible_facts['distribution'] == 'Ubuntu') | ternary(ansible_facts['distribution_version'], ansible_facts['distribution_major_version']) }}"
   register: __foreman_openvox_apt_deb_install
 
 - name: Update apt cache if necessary

--- a/roles/openvox_repositories/tasks/main.yml
+++ b/roles/openvox_repositories/tasks/main.yml
@@ -5,5 +5,5 @@
     state: absent
   loop: "{{ foreman_openvox_repositories_supported_versions | difference([foreman_openvox_repositories_version | string]) }}"
 
-- name: 'Include {{ ansible_os_family }}'
-  ansible.builtin.include_tasks: '{{ ansible_os_family | lower }}.yml'
+- name: 'Include {{ ansible_facts["os_family"] }}'
+  ansible.builtin.include_tasks: '{{ ansible_facts["os_family"] | lower }}.yml'

--- a/roles/openvox_repositories/tasks/redhat.yml
+++ b/roles/openvox_repositories/tasks/redhat.yml
@@ -1,6 +1,6 @@
 ---
 - name: 'Setup OpenVox repository'
   ansible.builtin.package:
-    name: https://yum.voxpupuli.org/openvox{{ foreman_openvox_repositories_version }}-release-el-{{ ansible_distribution_major_version }}.noarch.rpm
+    name: https://yum.voxpupuli.org/openvox{{ foreman_openvox_repositories_version }}-release-el-{{ ansible_facts['distribution_major_version'] }}.noarch.rpm
     disable_gpg_check: true
     state: present


### PR DESCRIPTION
This was done in fc60b9ab36f9bceffd095a7575bdaa31662fc3c2 for the whole collection, but openvox_repositories was added later and not updated