### PR TITLE
Add virt_who role to deploy and configure virt-who

### DIFF
--- a/roles/virt_who/README.md
+++ b/roles/virt_who/README.md
@@ -1,0 +1,85 @@
+theforeman.operations.virt_who
+==============================
+
+Install and configure virt-who for hypervisor-to-Foreman/Satellite reporting.
+
+This role replaces the bash deployment script from the `foreman_virt_who_configure` plugin with an idempotent Ansible role. It installs virt-who, encrypts credentials, writes the per-config and global configuration files, and manages the virt-who service.
+
+Requirements
+------------
+
+- Target host must be RHEL/CentOS family
+- virt-who >= 0.24.2 must be available in configured repositories
+- The `virt-who-password` utility (shipped with virt-who) is used for credential encryption
+
+Role Variables
+--------------
+
+Required:
+
+- `foreman_virt_who_hypervisor_type`: Hypervisor type — `esx`, `hyperv`, `libvirt`, `kubevirt`, or `ahv`.
+- `foreman_virt_who_satellite_url`: Foreman or Satellite FQDN (used as `rhsm_hostname`).
+- `foreman_virt_who_organization_label`: Organization label (Candlepin owner).
+- `foreman_virt_who_service_user`: RHSM service user username.
+- `foreman_virt_who_service_user_password`: RHSM service user password (will be encrypted on the target host).
+
+Conditionally required:
+
+- `foreman_virt_who_hypervisor_server`: Hypervisor server URL/hostname. Required for all types except `kubevirt`.
+- `foreman_virt_who_hypervisor_username`: Hypervisor username. Required for all types except `kubevirt`.
+- `foreman_virt_who_hypervisor_password`: Hypervisor password (will be encrypted on the target host). Required for `esx`, `hyperv`, and `ahv`.
+- `foreman_virt_who_kubeconfig_path`: Path to kubeconfig file. Required for `kubevirt`.
+
+Optional:
+
+- `foreman_virt_who_identifier`: Config section name and filename base. Default: `virt-who-config`.
+- `foreman_virt_who_hypervisor_id`: Hypervisor identification method — `hostname`, `uuid`, or `hwuuid`. Default: `hostname`.
+- `foreman_virt_who_interval`: Reporting interval in seconds. Default: `7200`.
+- `foreman_virt_who_debug`: Enable debug logging. Default: `false`.
+- `foreman_virt_who_filtering_mode`: Host filtering mode — `none`, `whitelist`, or `blacklist`. Default: `none`.
+- `foreman_virt_who_whitelist`: Comma-separated list of hosts to include (when filtering_mode is `whitelist`).
+- `foreman_virt_who_blacklist`: Comma-separated list of hosts to exclude (when filtering_mode is `blacklist`).
+- `foreman_virt_who_filter_host_parents`: Comma-separated list of parent compute resources to include (ESX, whitelist mode).
+- `foreman_virt_who_exclude_host_parents`: Comma-separated list of parent compute resources to exclude (ESX, blacklist mode).
+- `foreman_virt_who_http_proxy`: Full proxy URL (e.g., `http://proxy.example.com:8080`).
+- `foreman_virt_who_no_proxy`: Comma-separated list of hosts/domains to bypass proxy.
+- `foreman_virt_who_prism_flavor`: AHV Prism type — `central` or `element`. Default: `central`.
+- `foreman_virt_who_ahv_internal_debug`: AHV internal debug value (only used when hypervisor_type is `ahv`).
+
+Example Playbooks
+-----------------
+
+Deploy a VMware ESX configuration:
+
+```yaml
+- hosts: virt-who-hosts
+  roles:
+    - role: theforeman.operations.virt_who
+      vars:
+        foreman_virt_who_identifier: virt-who-config-1
+        foreman_virt_who_hypervisor_type: esx
+        foreman_virt_who_hypervisor_server: vcenter.example.com
+        foreman_virt_who_hypervisor_username: readonly@vsphere.local
+        foreman_virt_who_hypervisor_password: changeme
+        foreman_virt_who_satellite_url: satellite.example.com
+        foreman_virt_who_organization_label: Default_Organization
+        foreman_virt_who_service_user: virt_who_reporter_1
+        foreman_virt_who_service_user_password: secret
+        foreman_virt_who_interval: 3600
+```
+
+Deploy a KubeVirt configuration:
+
+```yaml
+- hosts: virt-who-hosts
+  roles:
+    - role: theforeman.operations.virt_who
+      vars:
+        foreman_virt_who_identifier: virt-who-config-2
+        foreman_virt_who_hypervisor_type: kubevirt
+        foreman_virt_who_kubeconfig_path: /etc/virt-who/kubeconfig
+        foreman_virt_who_satellite_url: satellite.example.com
+        foreman_virt_who_organization_label: Default_Organization
+        foreman_virt_who_service_user: virt_who_reporter_2
+        foreman_virt_who_service_user_password: secret
+```

--- a/roles/virt_who/defaults/main.yml
+++ b/roles/virt_who/defaults/main.yml
@@ -1,0 +1,17 @@
+---
+foreman_virt_who_identifier: virt-who-config
+foreman_virt_who_hypervisor_id: hostname
+foreman_virt_who_interval: 7200
+foreman_virt_who_debug: false
+foreman_virt_who_filtering_mode: none
+foreman_virt_who_whitelist: ''
+foreman_virt_who_blacklist: ''
+foreman_virt_who_filter_host_parents: ''
+foreman_virt_who_exclude_host_parents: ''
+foreman_virt_who_http_proxy: ''
+foreman_virt_who_no_proxy: ''
+foreman_virt_who_prism_flavor: central
+foreman_virt_who_ahv_internal_debug: ''
+foreman_virt_who_minimum_version: '0.24.2'
+foreman_virt_who_config_dir: /etc/virt-who.d
+foreman_virt_who_global_config_path: /etc/virt-who.conf

--- a/roles/virt_who/handlers/main.yml
+++ b/roles/virt_who/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: Restart virt-who
+  ansible.builtin.service:
+    name: virt-who
+    state: restarted

--- a/roles/virt_who/meta/main.yml
+++ b/roles/virt_who/meta/main.yml
@@ -1,0 +1,3 @@
+galaxy_info:
+  description: Install and configure virt-who
+  standalone: false

--- a/roles/virt_who/molecule/default/converge.yml
+++ b/roles/virt_who/molecule/default/converge.yml
@@ -1,0 +1,107 @@
+---
+- name: Converge
+  hosts: all
+  gather_facts: true
+  roles:
+    # ESX with debug and all standard fields
+    - role: virt_who
+      vars:
+        foreman_virt_who_identifier: virt-who-config-esx
+        foreman_virt_who_hypervisor_type: esx
+        foreman_virt_who_hypervisor_server: vcenter.example.com
+        foreman_virt_who_hypervisor_username: readonly@vsphere.local
+        foreman_virt_who_hypervisor_password: changeme
+        foreman_virt_who_hypervisor_id: hostname
+        foreman_virt_who_satellite_url: satellite.example.com
+        foreman_virt_who_organization_label: Default_Organization
+        foreman_virt_who_service_user: virt_who_reporter_1
+        foreman_virt_who_service_user_password: secret
+        foreman_virt_who_interval: 3600
+        foreman_virt_who_debug: true
+
+    # Libvirt — no encrypted_password in config
+    - role: virt_who
+      vars:
+        foreman_virt_who_identifier: virt-who-config-libvirt
+        foreman_virt_who_hypervisor_type: libvirt
+        foreman_virt_who_hypervisor_server: qemu+ssh://root@kvm.example.com/system
+        foreman_virt_who_hypervisor_username: root
+        foreman_virt_who_hypervisor_id: hostname
+        foreman_virt_who_satellite_url: satellite.example.com
+        foreman_virt_who_organization_label: Default_Organization
+        foreman_virt_who_service_user: virt_who_reporter_2
+        foreman_virt_who_service_user_password: secret2
+        foreman_virt_who_interval: 7200
+        foreman_virt_who_debug: false
+
+    # KubeVirt — no server/username/password, has kubeconfig
+    - role: virt_who
+      vars:
+        foreman_virt_who_identifier: virt-who-config-kubevirt
+        foreman_virt_who_hypervisor_type: kubevirt
+        foreman_virt_who_kubeconfig_path: /etc/virt-who/kubeconfig
+        foreman_virt_who_hypervisor_id: uuid
+        foreman_virt_who_satellite_url: satellite.example.com
+        foreman_virt_who_organization_label: Default_Organization
+        foreman_virt_who_service_user: virt_who_reporter_3
+        foreman_virt_who_service_user_password: secret3
+        foreman_virt_who_interval: 3600
+        foreman_virt_who_debug: false
+
+    # AHV with prism_central and ahv_internal_debug
+    - role: virt_who
+      vars:
+        foreman_virt_who_identifier: virt-who-config-ahv
+        foreman_virt_who_hypervisor_type: ahv
+        foreman_virt_who_hypervisor_server: prism.example.com
+        foreman_virt_who_hypervisor_username: admin
+        foreman_virt_who_hypervisor_password: nutanix123
+        foreman_virt_who_hypervisor_id: hostname
+        foreman_virt_who_satellite_url: satellite.example.com
+        foreman_virt_who_organization_label: Default_Organization
+        foreman_virt_who_service_user: virt_who_reporter_4
+        foreman_virt_who_service_user_password: secret4
+        foreman_virt_who_prism_flavor: element
+        foreman_virt_who_ahv_internal_debug: '1'
+        foreman_virt_who_interval: 7200
+        foreman_virt_who_debug: false
+
+    # ESX with whitelist filtering and proxy
+    - role: virt_who
+      vars:
+        foreman_virt_who_identifier: virt-who-config-filtered
+        foreman_virt_who_hypervisor_type: esx
+        foreman_virt_who_hypervisor_server: vcenter2.example.com
+        foreman_virt_who_hypervisor_username: readonly@vsphere.local
+        foreman_virt_who_hypervisor_password: changeme
+        foreman_virt_who_hypervisor_id: hwuuid
+        foreman_virt_who_satellite_url: satellite.example.com
+        foreman_virt_who_organization_label: Default_Organization
+        foreman_virt_who_service_user: virt_who_reporter_5
+        foreman_virt_who_service_user_password: secret5
+        foreman_virt_who_filtering_mode: whitelist
+        foreman_virt_who_whitelist: host1.example.com,host2.example.com
+        foreman_virt_who_filter_host_parents: cluster1,cluster2
+        foreman_virt_who_http_proxy: http://proxy.example.com:8080
+        foreman_virt_who_no_proxy: satellite.example.com,internal.example.com
+        foreman_virt_who_interval: 3600
+        foreman_virt_who_debug: false
+
+    # ESX with blacklist filtering
+    - role: virt_who
+      vars:
+        foreman_virt_who_identifier: virt-who-config-blacklist
+        foreman_virt_who_hypervisor_type: esx
+        foreman_virt_who_hypervisor_server: vcenter3.example.com
+        foreman_virt_who_hypervisor_username: readonly@vsphere.local
+        foreman_virt_who_hypervisor_password: changeme
+        foreman_virt_who_hypervisor_id: hostname
+        foreman_virt_who_satellite_url: satellite.example.com
+        foreman_virt_who_organization_label: Default_Organization
+        foreman_virt_who_service_user: virt_who_reporter_6
+        foreman_virt_who_service_user_password: secret6
+        foreman_virt_who_filtering_mode: blacklist
+        foreman_virt_who_blacklist: dev-host1.example.com
+        foreman_virt_who_exclude_host_parents: dev-cluster
+        foreman_virt_who_interval: 3600
+        foreman_virt_who_debug: false

--- a/roles/virt_who/molecule/default/molecule.yml
+++ b/roles/virt_who/molecule/default/molecule.yml
@@ -1,0 +1,13 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ${DRIVER_NAME:-podman}
+platforms:
+  - name: centos9
+    image: quay.io/centos/centos:stream9
+    command: /sbin/init
+provisioner:
+  name: ansible
+verifier:
+  name: ansible

--- a/roles/virt_who/molecule/default/verify.yml
+++ b/roles/virt_who/molecule/default/verify.yml
@@ -1,0 +1,165 @@
+---
+- name: Verify
+  hosts: all
+  gather_facts: false
+  tasks:
+    # --- Package and service ---
+    - name: Ensure virt-who is installed
+      ansible.builtin.package:
+        name: virt-who
+        state: present
+
+    - name: Ensure virt-who service is enabled
+      ansible.builtin.service:
+        name: virt-who
+        enabled: true
+
+    # --- ESX config ---
+    - name: Read ESX config file
+      ansible.builtin.slurp:
+        src: /etc/virt-who.d/virt-who-config-esx.conf
+      register: __foreman_virt_who_esx
+
+    - name: Assert ESX config contains expected values
+      ansible.builtin.assert:
+        that:
+          - "'[virt-who-config-esx]' in __foreman_virt_who_content"
+          - "'type=esx' in __foreman_virt_who_content"
+          - "'hypervisor_id=hostname' in __foreman_virt_who_content"
+          - "'owner=Default_Organization' in __foreman_virt_who_content"
+          - "'server=vcenter.example.com' in __foreman_virt_who_content"
+          - "'username=readonly@vsphere.local' in __foreman_virt_who_content"
+          - "'encrypted_password=' in __foreman_virt_who_content"
+          - "'rhsm_hostname=satellite.example.com' in __foreman_virt_who_content"
+          - "'rhsm_username=virt_who_reporter_1' in __foreman_virt_who_content"
+          - "'rhsm_encrypted_password=' in __foreman_virt_who_content"
+          - "'rhsm_prefix=/rhsm' in __foreman_virt_who_content"
+          - "'filter_hosts=' not in __foreman_virt_who_content"
+          - "'kubeconfig=' not in __foreman_virt_who_content"
+          - "'prism_central=' not in __foreman_virt_who_content"
+      vars:
+        __foreman_virt_who_content: "{{ __foreman_virt_who_esx['content'] | b64decode }}"
+
+    # --- Libvirt config ---
+    - name: Read libvirt config file
+      ansible.builtin.slurp:
+        src: /etc/virt-who.d/virt-who-config-libvirt.conf
+      register: __foreman_virt_who_libvirt
+
+    - name: Assert libvirt config has server and username but no encrypted_password
+      ansible.builtin.assert:
+        that:
+          - "'[virt-who-config-libvirt]' in __foreman_virt_who_content"
+          - "'type=libvirt' in __foreman_virt_who_content"
+          - "'server=qemu+ssh://root@kvm.example.com/system' in __foreman_virt_who_content"
+          - "'username=root' in __foreman_virt_who_content"
+          - "'encrypted_password=' not in __foreman_virt_who_content"
+      vars:
+        __foreman_virt_who_content: "{{ __foreman_virt_who_libvirt['content'] | b64decode }}"
+
+    # --- KubeVirt config ---
+    - name: Read kubevirt config file
+      ansible.builtin.slurp:
+        src: /etc/virt-who.d/virt-who-config-kubevirt.conf
+      register: __foreman_virt_who_kubevirt
+
+    - name: Assert kubevirt config has kubeconfig but no server or password
+      ansible.builtin.assert:
+        that:
+          - "'[virt-who-config-kubevirt]' in __foreman_virt_who_content"
+          - "'type=kubevirt' in __foreman_virt_who_content"
+          - "'hypervisor_id=uuid' in __foreman_virt_who_content"
+          - "'kubeconfig=/etc/virt-who/kubeconfig' in __foreman_virt_who_content"
+          - "'server=' not in __foreman_virt_who_content"
+          - "'username=' not in __foreman_virt_who_content"
+          - "'encrypted_password=' not in __foreman_virt_who_content"
+      vars:
+        __foreman_virt_who_content: "{{ __foreman_virt_who_kubevirt['content'] | b64decode }}"
+
+    # --- AHV config ---
+    - name: Read AHV config file
+      ansible.builtin.slurp:
+        src: /etc/virt-who.d/virt-who-config-ahv.conf
+      register: __foreman_virt_who_ahv
+
+    - name: Assert AHV config has prism and debug options
+      ansible.builtin.assert:
+        that:
+          - "'[virt-who-config-ahv]' in __foreman_virt_who_content"
+          - "'type=ahv' in __foreman_virt_who_content"
+          - "'server=prism.example.com' in __foreman_virt_who_content"
+          - "'encrypted_password=' in __foreman_virt_who_content"
+          - "'prism_central=false' in __foreman_virt_who_content"
+          - "'ahv_internal_debug=1' in __foreman_virt_who_content"
+      vars:
+        __foreman_virt_who_content: "{{ __foreman_virt_who_ahv['content'] | b64decode }}"
+
+    # --- Whitelist filtering + proxy config ---
+    - name: Read whitelist-filtered config file
+      ansible.builtin.slurp:
+        src: /etc/virt-who.d/virt-who-config-filtered.conf
+      register: __foreman_virt_who_filtered
+
+    - name: Assert whitelist filtering is present
+      ansible.builtin.assert:
+        that:
+          - "'[virt-who-config-filtered]' in __foreman_virt_who_content"
+          - "'hypervisor_id=hwuuid' in __foreman_virt_who_content"
+          - "'filter_hosts=host1.example.com,host2.example.com' in __foreman_virt_who_content"
+          - "'filter_host_parents=cluster1,cluster2' in __foreman_virt_who_content"
+          - "'exclude_hosts=' not in __foreman_virt_who_content"
+      vars:
+        __foreman_virt_who_content: "{{ __foreman_virt_who_filtered['content'] | b64decode }}"
+
+    # --- Blacklist filtering config ---
+    - name: Read blacklist-filtered config file
+      ansible.builtin.slurp:
+        src: /etc/virt-who.d/virt-who-config-blacklist.conf
+      register: __foreman_virt_who_blacklist
+
+    - name: Assert blacklist filtering is present
+      ansible.builtin.assert:
+        that:
+          - "'[virt-who-config-blacklist]' in __foreman_virt_who_content"
+          - "'exclude_hosts=dev-host1.example.com' in __foreman_virt_who_content"
+          - "'exclude_host_parents=dev-cluster' in __foreman_virt_who_content"
+          - "'filter_hosts=' not in __foreman_virt_who_content"
+      vars:
+        __foreman_virt_who_content: "{{ __foreman_virt_who_blacklist['content'] | b64decode }}"
+
+    # --- Global config (last role invocation wins) ---
+    - name: Read global config file
+      ansible.builtin.slurp:
+        src: /etc/virt-who.conf
+      register: __foreman_virt_who_global
+
+    - name: Assert global config contains expected values
+      ansible.builtin.assert:
+        that:
+          - "'[global]' in __foreman_virt_who_content"
+          - "'interval=' in __foreman_virt_who_content"
+          - "'oneshot=False' in __foreman_virt_who_content"
+          - "'[system_environment]' in __foreman_virt_who_content"
+      vars:
+        __foreman_virt_who_content: "{{ __foreman_virt_who_global['content'] | b64decode }}"
+
+    # --- Verify all six config files coexist ---
+    - name: Check all config files exist
+      ansible.builtin.stat:
+        path: "/etc/virt-who.d/{{ item }}.conf"
+      register: __foreman_virt_who_all_configs
+      loop:
+        - virt-who-config-esx
+        - virt-who-config-libvirt
+        - virt-who-config-kubevirt
+        - virt-who-config-ahv
+        - virt-who-config-filtered
+        - virt-who-config-blacklist
+
+    - name: Assert all config files exist
+      ansible.builtin.assert:
+        that:
+          - item.stat.exists
+      loop: "{{ __foreman_virt_who_all_configs.results }}"
+      loop_control:
+        label: "{{ item.item }}"

--- a/roles/virt_who/molecule/validation/converge.yml
+++ b/roles/virt_who/molecule/validation/converge.yml
@@ -1,0 +1,93 @@
+---
+- name: Converge - test validation failures
+  hosts: all
+  gather_facts: true
+  tasks:
+    # Missing required variable should fail
+    - name: Test missing hypervisor_type fails
+      block:
+        - name: Run role without hypervisor_type
+          ansible.builtin.include_role:
+            name: virt_who
+          vars:
+            foreman_virt_who_satellite_url: satellite.example.com
+            foreman_virt_who_organization_label: Default_Organization
+            foreman_virt_who_service_user: virt_who_reporter_1
+            foreman_virt_who_service_user_password: secret
+
+        - name: Fail if role did not error
+          ansible.builtin.fail:
+            msg: Role should have failed due to missing hypervisor_type
+      rescue:
+        - name: Confirm expected failure for missing hypervisor_type
+          ansible.builtin.debug:
+            msg: "Correctly failed: missing hypervisor_type"
+
+    # Empty password should fail for ESX
+    - name: Test empty password fails for ESX
+      block:
+        - name: Run role with empty hypervisor_password
+          ansible.builtin.include_role:
+            name: virt_who
+          vars:
+            foreman_virt_who_hypervisor_type: esx
+            foreman_virt_who_hypervisor_server: vcenter.example.com
+            foreman_virt_who_hypervisor_username: root
+            foreman_virt_who_hypervisor_password: ''
+            foreman_virt_who_satellite_url: satellite.example.com
+            foreman_virt_who_organization_label: Default_Organization
+            foreman_virt_who_service_user: virt_who_reporter_1
+            foreman_virt_who_service_user_password: secret
+
+        - name: Fail if role did not error
+          ansible.builtin.fail:
+            msg: Role should have failed due to empty hypervisor_password
+      rescue:
+        - name: Confirm expected failure for empty password
+          ansible.builtin.debug:
+            msg: "Correctly failed: empty hypervisor_password for ESX"
+
+    # Invalid hypervisor type should fail
+    - name: Test invalid hypervisor_type fails
+      block:
+        - name: Run role with invalid hypervisor_type
+          ansible.builtin.include_role:
+            name: virt_who
+          vars:
+            foreman_virt_who_hypervisor_type: vmware
+            foreman_virt_who_hypervisor_server: vcenter.example.com
+            foreman_virt_who_hypervisor_username: root
+            foreman_virt_who_hypervisor_password: changeme
+            foreman_virt_who_satellite_url: satellite.example.com
+            foreman_virt_who_organization_label: Default_Organization
+            foreman_virt_who_service_user: virt_who_reporter_1
+            foreman_virt_who_service_user_password: secret
+
+        - name: Fail if role did not error
+          ansible.builtin.fail:
+            msg: Role should have failed due to invalid hypervisor_type
+      rescue:
+        - name: Confirm expected failure for invalid type
+          ansible.builtin.debug:
+            msg: "Correctly failed: invalid hypervisor_type"
+
+    # KubeVirt without kubeconfig should fail
+    - name: Test kubevirt without kubeconfig fails
+      block:
+        - name: Run role with kubevirt but no kubeconfig_path
+          ansible.builtin.include_role:
+            name: virt_who
+          vars:
+            foreman_virt_who_hypervisor_type: kubevirt
+            foreman_virt_who_satellite_url: satellite.example.com
+            foreman_virt_who_organization_label: Default_Organization
+            foreman_virt_who_service_user: virt_who_reporter_1
+            foreman_virt_who_service_user_password: secret
+
+        - name: Fail if role did not error
+          ansible.builtin.fail:
+            msg: Role should have failed due to missing kubeconfig_path
+      rescue:
+        - name: Confirm expected failure for missing kubeconfig
+          ansible.builtin.debug:
+            msg: "Correctly failed: missing kubeconfig_path for kubevirt"

--- a/roles/virt_who/molecule/validation/molecule.yml
+++ b/roles/virt_who/molecule/validation/molecule.yml
@@ -1,0 +1,13 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ${DRIVER_NAME:-podman}
+platforms:
+  - name: centos9
+    image: quay.io/centos/centos:stream9
+    command: /sbin/init
+provisioner:
+  name: ansible
+verifier:
+  name: ansible

--- a/roles/virt_who/molecule/validation/verify.yml
+++ b/roles/virt_who/molecule/validation/verify.yml
@@ -1,0 +1,8 @@
+---
+- name: Verify
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Validation tests passed in converge
+      ansible.builtin.debug:
+        msg: All expected validation failures were caught correctly

--- a/roles/virt_who/tasks/main.yml
+++ b/roles/virt_who/tasks/main.yml
@@ -1,0 +1,160 @@
+---
+- name: Check that required variables are defined
+  ansible.builtin.assert:
+    that:
+      - foreman_virt_who_hypervisor_type is defined and foreman_virt_who_hypervisor_type | length > 0
+      - foreman_virt_who_hypervisor_type in ['esx', 'hyperv', 'libvirt', 'kubevirt', 'ahv']
+      - foreman_virt_who_satellite_url is defined and foreman_virt_who_satellite_url | length > 0
+      - foreman_virt_who_organization_label is defined and foreman_virt_who_organization_label | length > 0
+      - foreman_virt_who_service_user is defined and foreman_virt_who_service_user | length > 0
+      - foreman_virt_who_service_user_password is defined and foreman_virt_who_service_user_password | length > 0
+    fail_msg: >-
+      Required variables must be defined and non-empty: foreman_virt_who_hypervisor_type (esx, hyperv, libvirt, kubevirt, ahv),
+      foreman_virt_who_satellite_url, foreman_virt_who_organization_label,
+      foreman_virt_who_service_user, foreman_virt_who_service_user_password
+
+- name: Check that hypervisor server and username are defined
+  ansible.builtin.assert:
+    that:
+      - foreman_virt_who_hypervisor_server is defined and foreman_virt_who_hypervisor_server | length > 0
+      - foreman_virt_who_hypervisor_username is defined and foreman_virt_who_hypervisor_username | length > 0
+    fail_msg: >-
+      foreman_virt_who_hypervisor_server and foreman_virt_who_hypervisor_username
+      are required for {{ foreman_virt_who_hypervisor_type }}
+  when: foreman_virt_who_hypervisor_type != 'kubevirt'
+
+- name: Check that hypervisor password is defined
+  ansible.builtin.assert:
+    that:
+      - foreman_virt_who_hypervisor_password is defined and foreman_virt_who_hypervisor_password | length > 0
+    fail_msg: >-
+      foreman_virt_who_hypervisor_password is required for {{ foreman_virt_who_hypervisor_type }}
+  when: foreman_virt_who_hypervisor_type in ['esx', 'hyperv', 'ahv']
+
+- name: Check that kubeconfig path is defined for kubevirt
+  ansible.builtin.assert:
+    that:
+      - foreman_virt_who_kubeconfig_path is defined and foreman_virt_who_kubeconfig_path | length > 0
+    fail_msg: foreman_virt_who_kubeconfig_path is required for kubevirt
+  when: foreman_virt_who_hypervisor_type == 'kubevirt'
+
+- name: Check if virt-who is already installed # noqa command-instead-of-module
+  ansible.builtin.command: rpm -q virt-who
+  register: __foreman_virt_who_installed
+  changed_when: false
+  failed_when: false
+
+- name: Install virt-who
+  when: __foreman_virt_who_installed.rc != 0
+  block:
+    - name: Check for satellite-maintain # noqa command-instead-of-module
+      ansible.builtin.command: rpm -q satellite-maintain
+      register: __foreman_virt_who_satellite_maintain
+      changed_when: false
+      failed_when: false
+
+    - name: Check for foreman-maintain # noqa command-instead-of-module
+      ansible.builtin.command: rpm -q rubygem-foreman_maintain
+      register: __foreman_virt_who_foreman_maintain
+      changed_when: false
+      failed_when: false
+      when: __foreman_virt_who_satellite_maintain.rc != 0
+
+    - name: Install virt-who using satellite-maintain # noqa no-changed-when
+      when: __foreman_virt_who_satellite_maintain.rc == 0
+      block:
+        - name: Unlock packages via satellite-maintain # noqa no-changed-when
+          ansible.builtin.command: satellite-maintain packages unlock
+
+        - name: Install virt-who via satellite-maintain # noqa no-changed-when
+          ansible.builtin.command: satellite-maintain advanced procedure run packages-install --packages virt-who --assumeyes
+
+        - name: Lock packages via satellite-maintain # noqa no-changed-when
+          ansible.builtin.command: satellite-maintain packages lock
+
+    - name: Install virt-who using foreman-maintain # noqa no-changed-when
+      when:
+        - __foreman_virt_who_satellite_maintain.rc != 0
+        - __foreman_virt_who_foreman_maintain.rc == 0
+      block:
+        - name: Unlock packages via foreman-maintain # noqa no-changed-when
+          ansible.builtin.command: foreman-maintain packages unlock
+
+        - name: Install virt-who via foreman-maintain # noqa no-changed-when
+          ansible.builtin.command: foreman-maintain advanced procedure run packages-install --packages virt-who --assumeyes
+
+        - name: Lock packages via foreman-maintain # noqa no-changed-when
+          ansible.builtin.command: foreman-maintain packages lock
+
+    - name: Install virt-who via package manager
+      ansible.builtin.package:
+        name: virt-who
+        state: present
+      when:
+        - __foreman_virt_who_satellite_maintain.rc != 0
+        - __foreman_virt_who_foreman_maintain.rc | default(1) != 0
+
+- name: Get installed virt-who version # noqa command-instead-of-module
+  ansible.builtin.command: rpm -q --queryformat '%{VERSION}' virt-who
+  register: __foreman_virt_who_installed_version
+  changed_when: false
+
+- name: Verify minimum virt-who version
+  ansible.builtin.assert:
+    that:
+      - __foreman_virt_who_installed_version.stdout is version(foreman_virt_who_minimum_version, '>=')
+    fail_msg: >-
+      virt-who {{ __foreman_virt_who_installed_version.stdout }} does not meet minimum requirements,
+      minimum version is {{ foreman_virt_who_minimum_version }}
+
+- name: Encrypt hypervisor password
+  ansible.builtin.command: virt-who-password --password '{{ foreman_virt_who_hypervisor_password }}'
+  register: __foreman_virt_who_cr_password_result
+  changed_when: false
+  no_log: true
+  when: foreman_virt_who_hypervisor_type in ['esx', 'hyperv', 'ahv']
+
+- name: Encrypt service user password
+  ansible.builtin.command: virt-who-password --password '{{ foreman_virt_who_service_user_password }}'
+  register: __foreman_virt_who_service_user_password_result
+  changed_when: false
+  no_log: true
+
+- name: Set encrypted password facts
+  ansible.builtin.set_fact:
+    __foreman_virt_who_cr_encrypted_password: "{{ __foreman_virt_who_cr_password_result.stdout | default('') }}"
+    __foreman_virt_who_service_user_encrypted_password: "{{ __foreman_virt_who_service_user_password_result.stdout }}"
+  no_log: true
+
+- name: Ensure virt-who config directory exists
+  ansible.builtin.file:
+    path: "{{ foreman_virt_who_config_dir }}"
+    state: directory
+    owner: root
+    group: root
+    mode: '0755'
+
+- name: Deploy virt-who per-config configuration
+  ansible.builtin.template:
+    src: virt_who_config.conf.j2
+    dest: "{{ foreman_virt_who_config_dir }}/{{ foreman_virt_who_identifier }}.conf"
+    owner: root
+    group: root
+    mode: '0640'
+  notify:
+    - Restart virt-who
+
+- name: Deploy virt-who global configuration
+  ansible.builtin.template:
+    src: virt_who.conf.j2
+    dest: "{{ foreman_virt_who_global_config_path }}"
+    owner: root
+    group: root
+    mode: '0644'
+  notify:
+    - Restart virt-who
+
+- name: Enable virt-who service
+  ansible.builtin.service:
+    name: virt-who
+    enabled: true

--- a/roles/virt_who/templates/virt_who.conf.j2
+++ b/roles/virt_who/templates/virt_who.conf.j2
@@ -1,0 +1,22 @@
+### This configuration file is managed via the virt-who configure plugin
+### manual edits will be deleted.
+[global]
+debug={{ 1 if foreman_virt_who_debug else 0 }}
+interval={{ foreman_virt_who_interval }}
+oneshot=False
+
+[system_environment]
+{% if foreman_virt_who_http_proxy | length > 0 -%}
+{% if '://' in foreman_virt_who_http_proxy -%}
+{% if foreman_virt_who_http_proxy.startswith('https') -%}
+https_proxy={{ foreman_virt_who_http_proxy }}
+{% else -%}
+http_proxy={{ foreman_virt_who_http_proxy }}
+{% endif -%}
+{% else -%}
+http_proxy={{ foreman_virt_who_http_proxy }}
+{% endif -%}
+{% endif -%}
+{% if foreman_virt_who_no_proxy | length > 0 -%}
+no_proxy={{ foreman_virt_who_no_proxy }}
+{% endif -%}

--- a/roles/virt_who/templates/virt_who_config.conf.j2
+++ b/roles/virt_who/templates/virt_who_config.conf.j2
@@ -1,0 +1,42 @@
+### This configuration file is managed via the virt-who configure plugin
+### manual edits will be deleted.
+[{{ foreman_virt_who_identifier }}]
+type={{ foreman_virt_who_hypervisor_type }}
+hypervisor_id={{ foreman_virt_who_hypervisor_id }}
+owner={{ foreman_virt_who_organization_label }}
+{% if foreman_virt_who_hypervisor_type == 'libvirt' -%}
+server={{ foreman_virt_who_hypervisor_server }}
+username={{ foreman_virt_who_hypervisor_username }}
+{% elif foreman_virt_who_hypervisor_type != 'kubevirt' -%}
+server={{ foreman_virt_who_hypervisor_server }}
+username={{ foreman_virt_who_hypervisor_username }}
+encrypted_password={{ __foreman_virt_who_cr_encrypted_password }}
+{% endif -%}
+{% if foreman_virt_who_filtering_mode == 'whitelist' -%}
+{% if foreman_virt_who_whitelist | length > 0 -%}
+filter_hosts={{ foreman_virt_who_whitelist }}
+{% endif -%}
+{% if foreman_virt_who_filter_host_parents | length > 0 -%}
+filter_host_parents={{ foreman_virt_who_filter_host_parents }}
+{% endif -%}
+{% elif foreman_virt_who_filtering_mode == 'blacklist' -%}
+{% if foreman_virt_who_blacklist | length > 0 -%}
+exclude_hosts={{ foreman_virt_who_blacklist }}
+{% endif -%}
+{% if foreman_virt_who_exclude_host_parents | length > 0 -%}
+exclude_host_parents={{ foreman_virt_who_exclude_host_parents }}
+{% endif -%}
+{% endif -%}
+rhsm_hostname={{ foreman_virt_who_satellite_url }}
+rhsm_username={{ foreman_virt_who_service_user }}
+rhsm_encrypted_password={{ __foreman_virt_who_service_user_encrypted_password }}
+rhsm_prefix=/rhsm
+{% if foreman_virt_who_hypervisor_type == 'kubevirt' -%}
+kubeconfig={{ foreman_virt_who_kubeconfig_path }}
+{% endif -%}
+{% if foreman_virt_who_hypervisor_type == 'ahv' -%}
+prism_central={{ (foreman_virt_who_prism_flavor == 'central') | lower }}
+{% if foreman_virt_who_ahv_internal_debug | length > 0 -%}
+ahv_internal_debug={{ foreman_virt_who_ahv_internal_debug }}
+{% endif -%}
+{% endif -%}


### PR DESCRIPTION
### Summary
- Adds a new virt_who role that converts the bash deployment script from the foreman_virt_who_configure plugin into an idempotent Ansible role
- Supports all hypervisor types: ESX, Hyper-V, libvirt, KubeVirt, and AHV
- Handles package installation with satellite-maintain/foreman-maintain package locking awareness, credential encryption via virt-who-password, config file templating, and service management
- Related [Jira](https://redhat.atlassian.net/browse/SAT-46996)

### Motivation
The foreman_virt_who_configure plugin currently generates a bash script that users must manually download, copy to the target host, and execute. This has no idempotency, no error recovery, and no integration with existing configuration management workflows. An Ansible role enables direct deployment via Foreman Remote Execution (REX) and fits into existing automation pipelines.

### Role details

Tasks:
  1. Validate required variables (with non-empty checks to prevent hangs on virt-who-password)
  2. Install virt-who — detects satellite-maintain / foreman-maintain for package locking, falls back to standard package manager
  3. Verify minimum virt-who version (>= 0.24.2)
  4. Encrypt hypervisor and service user passwords on the target host using virt-who-password
  5. Template per-config file to /etc/virt-who.d/<identifier>.conf
  6. Template global config to /etc/virt-who.conf
  7. Enable service; restart via handler only when config files change

Features:
  - Host filtering (whitelist/blacklist) with parent compute resource support
  - HTTP/HTTPS proxy and no_proxy configuration
  - AHV-specific options (Prism Central/Element, internal debug)
  - KubeVirt kubeconfig support
  - Multiple configs can be deployed to the same host with different identifiers
  - Passwords handled with no_log: true

Test plan

  - [X] molecule/default/ — deploys 6 configs covering all hypervisor types, whitelist/blacklist filtering, and proxy settings; verifies config file content and service state
  - [X] molecule/validation/ — verifies assertion failures for missing required vars, empty passwords, invalid hypervisor type, and missing kubeconfig
  - [X] Manual end-to-end test against a subscribed host with virt-who available

Manual tested on a VM checked out with broker and deployed 3 configs with three different organizations and all reported correctly, virt-who got installed and started up correctly, rerunning the role was idempotent:

```bash
[vagrant@host foreman_virt_who_configure]$ cd ../foreman-operations-collection/
[vagrant@host foreman-operations-collection]$ ANSIBLE_ROLES_PATH=/home/vagrant/foreman-operations-collection/roles ansible-playbook -i 10.0.0.0, test_virtwho.yml -k -u root
SSH password:

PLAY [all] ******************************************************************************************************************************************************************************************************

TASK [Gathering Facts] ******************************************************************************************************************************************************************************************
ok: [10.0.0.0]

TASK [virt_who : Check that required variables are defined] *****************************************************************************************************************************************************
ok: [10.0.0.0] => {
    "changed": false,
    "msg": "All assertions passed"
}

TASK [virt_who : Check that hypervisor server and username are defined] *****************************************************************************************************************************************
ok: [10.0.0.0] => {
    "changed": false,
    "msg": "All assertions passed"
}

TASK [virt_who : Check that hypervisor password is defined] *****************************************************************************************************************************************************
ok: [10.0.0.0] => {
    "changed": false,
    "msg": "All assertions passed"
}

TASK [virt_who : Check that kubeconfig path is defined for kubevirt] ********************************************************************************************************************************************
skipping: [10.0.0.0]

TASK [virt_who : Check if virt-who is already installed] ********************************************************************************************************************************************************
ok: [10.0.0.0]

TASK [virt_who : Check for satellite-maintain] ******************************************************************************************************************************************************************
skipping: [10.0.0.0]

TASK [virt_who : Check for foreman-maintain] ********************************************************************************************************************************************************************
skipping: [10.0.0.0]

TASK [virt_who : Unlock packages via satellite-maintain] ********************************************************************************************************************************************************
skipping: [10.0.0.0]

TASK [virt_who : Install virt-who via satellite-maintain] *******************************************************************************************************************************************************
skipping: [10.0.0.0]

TASK [virt_who : Lock packages via satellite-maintain] **********************************************************************************************************************************************************
skipping: [10.0.0.0]

TASK [virt_who : Unlock packages via foreman-maintain] **********************************************************************************************************************************************************
skipping: [10.0.0.0]

TASK [virt_who : Install virt-who via foreman-maintain] *********************************************************************************************************************************************************
skipping: [10.0.0.0]

TASK [virt_who : Lock packages via foreman-maintain] ************************************************************************************************************************************************************
skipping: [10.0.0.0]

TASK [virt_who : Install virt-who via package manager] **********************************************************************************************************************************************************
skipping: [10.0.0.0]

TASK [virt_who : Get installed virt-who version] ****************************************************************************************************************************************************************
ok: [10.0.0.0]

TASK [virt_who : Verify minimum virt-who version] ***************************************************************************************************************************************************************
ok: [10.0.0.0] => {
    "changed": false,
    "msg": "All assertions passed"
}

TASK [virt_who : Encrypt hypervisor password] *******************************************************************************************************************************************************************
ok: [10.0.0.0]

TASK [virt_who : Encrypt service user password] *****************************************************************************************************************************************************************
ok: [10.0.0.0]

TASK [virt_who : Set encrypted password facts] ******************************************************************************************************************************************************************
ok: [10.0.0.0]

TASK [virt_who : Ensure virt-who config directory exists] *******************************************************************************************************************************************************
ok: [10.0.0.0]

TASK [virt_who : Deploy virt-who per-config configuration] ******************************************************************************************************************************************************
ok: [10.0.0.0]

TASK [virt_who : Deploy virt-who global configuration] **********************************************************************************************************************************************************
ok: [10.0.0.0]

TASK [virt_who : Enable virt-who service] ***********************************************************************************************************************************************************************
ok: [10.0.0.0]

PLAY RECAP ******************************************************************************************************************************************************************************************************
10.0.0.0               : ok=14   changed=0    unreachable=0    failed=0    skipped=10   rescued=0    ignored=0
```